### PR TITLE
Adding experimental command to list validators

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -206,6 +206,7 @@ yargs // eslint-disable-line
     .command(login)
     .command(require('../commands/repl'))
     .command(require('../commands/generate-key'))
+    .command(require('../commands/validators'))
     .config(config)
     .alias({
         'accountId': ['account_id'],

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -196,6 +196,7 @@ yargs // eslint-disable-line
     .command(require('../commands/repl'))
     .command(require('../commands/generate-key'))
     .command(require('../commands/validators'))
+    .command(require('../commands/proposals'))
     .config(config)
     .alias({
         'accountId': ['account_id'],

--- a/commands/proposals.js
+++ b/commands/proposals.js
@@ -1,0 +1,12 @@
+const exitOnError = require('../utils/exit-on-error');
+const connect = require('../utils/connect');
+const validatorsInfo = require('../utils/validators-info');
+
+module.exports = {
+    command: 'proposals',
+    desc: 'lookup current proposals',
+    handler: exitOnError(async (argv) => {
+        const near = await connect(argv);
+        await validatorsInfo.showProposalsTable(near);
+    })
+};

--- a/commands/validators.js
+++ b/commands/validators.js
@@ -1,7 +1,5 @@
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
-const inspectResponse = require('../utils/inspect-response');
-const bs58 = require('bs58');
 const { utils } = require('near-api-js');
 const BN = require('bn.js');
 const AsciiTable = require('ascii-table');
@@ -12,10 +10,7 @@ function findSeatPrice(validators, numSeats) {
     let stakesSum = stakes.reduce((a, b) => a.add(b));
     // assert stakesSum >= numSeats
     let left = new BN(1), right = stakesSum.add(new BN(1));
-    while (true) {
-        if (left.eq(right.sub(new BN(1)))) {
-            return left;
-        }
+    while (!left.eq(right.sub(new BN(1)))) {
         const mid = left.add(right).div(new BN(2));
         let found = false;
         let currentSum = new BN(0);
@@ -31,6 +26,7 @@ function findSeatPrice(validators, numSeats) {
             right = mid;
         }
     }
+    return left;
 }
 
 function diffValidators(currentValidators, nextValidators) {

--- a/commands/validators.js
+++ b/commands/validators.js
@@ -6,10 +6,54 @@ const { utils } = require('near-api-js');
 const BN = require('bn.js');
 const AsciiTable = require('ascii-table');
 
-function findSeatPrice(validators) {
-    let stakes = validators.map((v) => new BN(v.stake, 10)).sort();
-    // TODO: find the correct price.
-    return stakes.reduce((a, b) => a.add(b)).div(new BN(stakes.length));
+function findSeatPrice(validators, numSeats) {
+    let stakes = validators.map((v) => new BN(v.stake, 10)).sort((a, b) => a.cmp(b));
+    let num = new BN(numSeats);
+    let stakesSum = stakes.reduce((a, b) => a.add(b));
+    // assert stakesSum >= numSeats
+    let left = new BN(1), right = stakesSum.add(new BN(1));
+    while (true) {
+        if (left.eq(right.sub(new BN(1)))) {
+            return left;
+        }
+        const mid = left.add(right).div(new BN(2));
+        let found = false;
+        let currentSum = new BN(0);
+        for (let i = 0; i < stakes.length; ++i) {
+            currentSum = currentSum.add(stakes[i].div(mid));
+            if (currentSum.gte(num)) {
+                left = mid;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            right = mid;
+        }
+    }
+}
+
+function diffValidators(currentValidators, nextValidators) {
+    const result = { newValidators: [], removedValidators: [], changeValidators: [] };
+    const validatorsMap = new Map();
+    const nextValidatorsMap = new Map();
+    nextValidators.map((validator) => nextValidatorsMap[validator.account_id] = validator);
+    currentValidators.map((validator) => { 
+        if (!(validator.account_id in nextValidatorsMap)) {
+            result.removedValidators.push(validator);
+        }
+        validatorsMap[validator.account_id] = validator;
+    });
+    nextValidators.map((validator) => {
+        if (validator.account_id in validatorsMap) {
+            if (validatorsMap[validator.account_id].stake != validator.stake) {
+                result.changeValidators.push({new: validator, old: validatorsMap[validator.account_id]});
+            }
+        } else {
+            result.newValidators.push(validator);
+        }
+    });
+    return result;
 }
 
 module.exports = {
@@ -18,21 +62,53 @@ module.exports = {
     handler: exitOnError(async (argv) => {
         const near = await connect(argv);
 
+        const genesisConfig = await near.connection.provider.sendJsonRpc('EXPERIMENTAL_genesis_config', {});
         const validators = await near.connection.provider.sendJsonRpc('validators', [null]);
 
+        // Calculate all required data.
+        const numSeats = genesisConfig.num_block_producer_seats + genesisConfig.avg_hidden_validator_seats_per_shard.reduce((a, b) => a + b);
+        const seatPrice = findSeatPrice(validators.current_validators, numSeats);
+        const nextSeatPrice = findSeatPrice(validators.next_validators, numSeats);
+
         var validatorsTable = new AsciiTable();
-        let seatPrice = findSeatPrice(validators.current_validators);
+        validatorsTable.setHeading('Validator Id', 'Stake', '# seats', '% online', 'bls produced', 'bls expected');
         console.log(`Validators (total: ${validators.current_validators.length}, seat price: ${utils.format.formatNearAmount(seatPrice, 0)}):`);
         validators.current_validators.forEach((validator) => {
-            validatorsTable.addRow(validator.account_id, utils.format.formatNearAmount(validator.stake, 0), new BN(validator.stake).divRound(seatPrice));
+            validatorsTable.addRow(
+                validator.account_id,
+                utils.format.formatNearAmount(validator.stake, 0),
+                new BN(validator.stake).divRound(seatPrice),
+                Math.floor(validator.num_produced_blocks / validator.num_expected_blocks * 100),
+                validator.num_produced_blocks,
+                validator.num_expected_blocks);
         });
         console.log(validatorsTable.toString());
 
-        console.log(`\nFishermen (total: ${validators.current_fishermen.length}):`);
-        var fishermenTable = new AsciiTable();
-        validators.current_fishermen.forEach((fisherman) => {
-            fishermenTable.addRow(fisherman.account_id, utils.format.formatNearAmount(fisherman.stake, 0));
-        });
-        console.log(fishermenTable.toString());
+        if (validators.current_fishermen) {
+            console.log(`\nFishermen (total: ${validators.current_fishermen.length}):`);
+            var fishermenTable = new AsciiTable();
+            fishermenTable.setHeading('Fisherman Id', 'Stake');
+            validators.current_fishermen.forEach((fisherman) => {
+                fishermenTable.addRow(fisherman.account_id, utils.format.formatNearAmount(fisherman.stake, 0));
+            });
+            console.log(fishermenTable.toString());
+        }
+
+        const diff = diffValidators(validators.current_validators, validators.next_validators);
+        console.log(`\nNext validators (total: ${validators.next_validators.length}, seat price: ${utils.format.formatNearAmount(nextSeatPrice, 0)}):`);
+        let nextValidatorsTable = new AsciiTable();
+        nextValidatorsTable.setHeading('Status', 'Validator', 'Stake', '# seats');
+        diff.newValidators.map((validator) => nextValidatorsTable.addRow(
+            'New',
+            validator.account_id,
+            utils.format.formatNearAmount(validator.stake, 0),
+            new BN(validator.stake).divRound(nextSeatPrice)));
+        diff.changeValidators.map((changeValidator) => nextValidatorsTable.addRow(
+            'Rewarded', 
+            changeValidator.new.account_id, 
+            `${utils.format.formatNearAmount(changeValidator.old.stake, 0)} -> ${utils.format.formatNearAmount(changeValidator.new.stake, 0)}`,
+            new BN(changeValidator.new.stake).divRound(nextSeatPrice)));
+        diff.removedValidators.map((validator) => nextValidatorsTable.addRow('Kicked out', validator.account_id, '-', '-'));
+        console.log(nextValidatorsTable.toString());
     })
 };

--- a/commands/validators.js
+++ b/commands/validators.js
@@ -1,0 +1,30 @@
+const exitOnError = require('../utils/exit-on-error');
+const connect = require('../utils/connect');
+const inspectResponse = require('../utils/inspect-response');
+const bs58 = require('bs58');
+const { utils } = require('near-api-js');
+const AsciiTable = require('ascii-table');
+
+module.exports = {
+    command: 'EXPERIMENTAL_validators',
+    desc: 'lookup validators and proposals',
+    handler: exitOnError(async (argv) => {
+        const near = await connect(argv);
+
+        const validators = await near.connection.provider.sendJsonRpc('validators', [null]);
+        console.log(`Validators (total: ${validators.current_validators.length}):`);
+
+        var validatorsTable = new AsciiTable();
+        validators.current_validators.forEach((validator) => {
+            validatorsTable.addRow(validator.account_id, utils.format.formatNearAmount(validator.stake, 0));
+        });
+        console.log(validatorsTable.toString());
+
+        console.log(`\nFishermen (total: ${validators.current_fishermen.length}):`);
+        var fishermenTable = new AsciiTable();
+        validators.current_fishermen.forEach((fisherman) => {
+            fishermenTable.addRow(fisherman.account_id, utils.format.formatNearAmount(fisherman.stake, 0));
+        });
+        console.log(fishermenTable.toString());
+    })
+};

--- a/commands/validators.js
+++ b/commands/validators.js
@@ -15,15 +15,15 @@ module.exports = {
         const near = await connect(argv);
 
         switch (argv.epoch) {
-            case 'current':
-                await validatorsInfo.showValidatorsTable(near, null);
-                break;
-            case 'next':
-                await validatorsInfo.showNextValidatorsTable(near);
-                break;
-            default:
-                await validatorsInfo.showValidatorsTable(near, argv.epoch);
-                break;
+        case 'current':
+            await validatorsInfo.showValidatorsTable(near, null);
+            break;
+        case 'next':
+            await validatorsInfo.showNextValidatorsTable(near);
+            break;
+        default:
+            await validatorsInfo.showValidatorsTable(near, argv.epoch);
+            break;
         }
     })
 };

--- a/commands/validators.js
+++ b/commands/validators.js
@@ -70,6 +70,10 @@ module.exports = {
         const seatPrice = findSeatPrice(validators.current_validators, numSeats);
         const nextSeatPrice = findSeatPrice(validators.next_validators, numSeats);
 
+        // Sort validators by their stake.
+        validators.current_validators = validators.current_validators.sort((a, b) => -new BN(a.stake).cmp(new BN(b.stake)));
+        validators.next_validators = validators.next_validators.sort((a, b) => -new BN(a.stake).cmp(new BN(b.stake)));
+
         var validatorsTable = new AsciiTable();
         validatorsTable.setHeading('Validator Id', 'Stake', '# seats', '% online', 'bls produced', 'bls expected');
         console.log(`Validators (total: ${validators.current_validators.length}, seat price: ${utils.format.formatNearAmount(seatPrice, 0)}):`);

--- a/commands/validators.js
+++ b/commands/validators.js
@@ -1,66 +1,29 @@
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
-const { validators, utils } = require('near-api-js');
-const BN = require('bn.js');
-const AsciiTable = require('ascii-table');
+const validatorsInfo = require('../utils/validators-info');
 
 module.exports = {
-    command: 'EXPERIMENTAL_validators',
-    desc: 'lookup validators and proposals',
+    command: 'validators <epoch>',
+    desc: 'lookup validators for given epoch (or current / next)',
+    builder: (yargs) => yargs
+        .option('epoch', {
+            desc: 'epoch defined by block number or current / next',
+            type: 'string',
+            required: true
+        }),
     handler: exitOnError(async (argv) => {
         const near = await connect(argv);
 
-        const genesisConfig = await near.connection.provider.sendJsonRpc('EXPERIMENTAL_genesis_config', {});
-        const result = await near.connection.provider.sendJsonRpc('validators', [null]);
-
-        // Calculate all required data.
-        const numSeats = genesisConfig.num_block_producer_seats + genesisConfig.avg_hidden_validator_seats_per_shard.reduce((a, b) => a + b);
-        const seatPrice = validators.findSeatPrice(result.current_validators, numSeats);
-        const nextSeatPrice = validators.findSeatPrice(result.next_validators, numSeats);
-
-        // Sort validators by their stake.
-        result.current_validators = result.current_validators.sort((a, b) => -new BN(a.stake).cmp(new BN(b.stake)));
-        result.next_validators = result.next_validators.sort((a, b) => -new BN(a.stake).cmp(new BN(b.stake)));
-
-        var validatorsTable = new AsciiTable();
-        validatorsTable.setHeading('Validator Id', 'Stake', '# seats', '% online', 'bls produced', 'bls expected');
-        console.log(`Validators (total: ${result.current_validators.length}, seat price: ${utils.format.formatNearAmount(seatPrice, 0)}):`);
-        result.current_validators.forEach((validator) => {
-            validatorsTable.addRow(
-                validator.account_id,
-                utils.format.formatNearAmount(validator.stake, 0),
-                new BN(validator.stake).divRound(seatPrice),
-                Math.floor(validator.num_produced_blocks / validator.num_expected_blocks * 100),
-                validator.num_produced_blocks,
-                validator.num_expected_blocks);
-        });
-        console.log(validatorsTable.toString());
-
-        if (result.current_fishermen) {
-            console.log(`\nFishermen (total: ${result.current_fishermen.length}):`);
-            var fishermenTable = new AsciiTable();
-            fishermenTable.setHeading('Fisherman Id', 'Stake');
-            result.current_fishermen.forEach((fisherman) => {
-                fishermenTable.addRow(fisherman.account_id, utils.format.formatNearAmount(fisherman.stake, 0));
-            });
-            console.log(fishermenTable.toString());
+        switch (argv.epoch) {
+            case 'current':
+                await validatorsInfo.showValidatorsTable(near, null);
+                break;
+            case 'next':
+                await validatorsInfo.showNextValidatorsTable(near);
+                break;
+            default:
+                await validatorsInfo.showValidatorsTable(near, argv.epoch);
+                break;
         }
-
-        const diff = validators.diffEpochValidators(result.current_validators, result.next_validators);
-        console.log(`\nNext validators (total: ${result.next_validators.length}, seat price: ${utils.format.formatNearAmount(nextSeatPrice, 0)}):`);
-        let nextValidatorsTable = new AsciiTable();
-        nextValidatorsTable.setHeading('Status', 'Validator', 'Stake', '# seats');
-        diff.newValidators.map((validator) => nextValidatorsTable.addRow(
-            'New',
-            validator.account_id,
-            utils.format.formatNearAmount(validator.stake, 0),
-            new BN(validator.stake).divRound(nextSeatPrice)));
-        diff.changedValidators.map((changeValidator) => nextValidatorsTable.addRow(
-            'Rewarded', 
-            changeValidator.next.account_id, 
-            `${utils.format.formatNearAmount(changeValidator.current.stake, 0)} -> ${utils.format.formatNearAmount(changeValidator.next.stake, 0)}`,
-            new BN(changeValidator.next.stake).divRound(nextSeatPrice)));
-        diff.removedValidators.map((validator) => nextValidatorsTable.addRow('Kicked out', validator.account_id, '-', '-'));
-        console.log(nextValidatorsTable.toString());
     })
 };

--- a/commands/validators.js
+++ b/commands/validators.js
@@ -3,7 +3,14 @@ const connect = require('../utils/connect');
 const inspectResponse = require('../utils/inspect-response');
 const bs58 = require('bs58');
 const { utils } = require('near-api-js');
+const BN = require('bn.js');
 const AsciiTable = require('ascii-table');
+
+function findSeatPrice(validators) {
+    let stakes = validators.map((v) => new BN(v.stake, 10)).sort();
+    // TODO: find the correct price.
+    return stakes.reduce((a, b) => a.add(b)).div(new BN(stakes.length));
+}
 
 module.exports = {
     command: 'EXPERIMENTAL_validators',
@@ -12,11 +19,12 @@ module.exports = {
         const near = await connect(argv);
 
         const validators = await near.connection.provider.sendJsonRpc('validators', [null]);
-        console.log(`Validators (total: ${validators.current_validators.length}):`);
 
         var validatorsTable = new AsciiTable();
+        let seatPrice = findSeatPrice(validators.current_validators);
+        console.log(`Validators (total: ${validators.current_validators.length}, seat price: ${utils.format.formatNearAmount(seatPrice, 0)}):`);
         validators.current_validators.forEach((validator) => {
-            validatorsTable.addRow(validator.account_id, utils.format.formatNearAmount(validator.stake, 0));
+            validatorsTable.addRow(validator.account_id, utils.format.formatNearAmount(validator.stake, 0), new BN(validator.stake).divRound(seatPrice));
         });
         console.log(validatorsTable.toString());
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "ascii-table": "0.0.9",
     "bn": "^1.0.5",
+    "bn.js": "^5.1.1",
     "bs58": "^4.0.1",
     "chalk": "^4.0.0",
     "flagged-respawn": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "strip-ansi-cli": "^2.0.0"
   },
   "dependencies": {
+    "ascii-table": "0.0.9",
     "bn": "^1.0.5",
     "bs58": "^4.0.1",
     "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jest-environment-node": "^26.0.0",
     "mixpanel": "^0.11.0",
     "ncp": "^2.0.0",
-    "near-api-js": "^0.23.1",
+    "near-api-js": "git+https://github.com/near/near-api-js.git",
     "open": "^7.0.1",
     "rimraf": "^3.0.0",
     "stoppable": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jest-environment-node": "^26.0.0",
     "mixpanel": "^0.11.0",
     "ncp": "^2.0.0",
-    "near-api-js": "git+https://github.com/near/near-api-js.git",
+    "near-api-js": "^0.24.0",
     "open": "^7.0.1",
     "rimraf": "^3.0.0",
     "stoppable": "^1.1.0",

--- a/utils/validators-info.js
+++ b/utils/validators-info.js
@@ -64,15 +64,15 @@ async function showProposalsTable(near) {
     result.current_proposals.forEach((p) => proposals.set(p.account_id, p));
     const combinedProposals = combineValidatorsAndProposals(result.current_validators, proposals);
     const expectedSeatPrice = validators.findSeatPrice(combinedProposals, result.numSeats);
-    console.log(`Proposals (total: ${proposals.size})`);
-    console.log(`Expected seat price = ${utils.format.formatNearAmount(expectedSeatPrice, 0)}`);
+    console.log(`Proposals for the epoch after next (total: ${proposals.size}, expected seat price = ${utils.format.formatNearAmount(expectedSeatPrice, 0)})`);
     const proposalsTable = new AsciiTable();
+    proposalsTable.setHeading('Status', 'Validator', 'Stake => New Stake');
     combinedProposals.sort((a, b) => -new BN(a.stake).cmp(new BN(b.stake))).forEach((proposal) => {
         let kind = '';
         if (new BN(proposal.stake).gte(expectedSeatPrice)) {
-            kind = proposals.has(proposal.account_id) ? 'New' : 'Rollover';
+            kind = proposals.has(proposal.account_id) ? 'Proposal(Accepted)' : 'Rollover';
         } else {
-            kind = proposals.has(proposal.account_id) ? 'Declined' : 'Kicked out';
+            kind = proposals.has(proposal.account_id) ? 'Proposal(Declined)' : 'Kicked out';
         }
         let stake_fmt = utils.format.formatNearAmount(proposal.stake, 0);
         if (currentValidators.has(proposal.account_id) && proposals.has(proposal.account_id)) {
@@ -85,6 +85,8 @@ async function showProposalsTable(near) {
         );
     });
     console.log(proposalsTable.toString());
+    console.log("Expected seat price is calculated based on observed so far proposals and validators.");
+    console.log("It can change from new proposals or some validators going offline.");
     console.log("Note: this currently doesn't account for offline kickouts and rewards for current epoch");
 }
 

--- a/utils/validators-info.js
+++ b/utils/validators-info.js
@@ -85,9 +85,9 @@ async function showProposalsTable(near) {
         );
     });
     console.log(proposalsTable.toString());
-    console.log("Expected seat price is calculated based on observed so far proposals and validators.");
-    console.log("It can change from new proposals or some validators going offline.");
-    console.log("Note: this currently doesn't account for offline kickouts and rewards for current epoch");
+    console.log('Expected seat price is calculated based on observed so far proposals and validators.');
+    console.log('It can change from new proposals or some validators going offline.');
+    console.log('Note: this currently doesn\'t account for offline kickouts and rewards for current epoch');
 }
 
 module.exports = { showValidatorsTable, showNextValidatorsTable, showProposalsTable };

--- a/utils/validators-info.js
+++ b/utils/validators-info.js
@@ -1,0 +1,91 @@
+const { validators, utils } = require('near-api-js');
+const BN = require('bn.js');
+const AsciiTable = require('ascii-table');
+
+async function validatorsInfo(near, epochId) {
+    const genesisConfig = await near.connection.provider.sendJsonRpc('EXPERIMENTAL_genesis_config', {});
+    const result = await near.connection.provider.sendJsonRpc('validators', [epochId]);
+    result.genesisConfig = genesisConfig;
+    result.numSeats = genesisConfig.num_block_producer_seats + genesisConfig.avg_hidden_validator_seats_per_shard.reduce((a, b) => a + b);
+    return result;
+}
+
+async function showValidatorsTable(near, epochId) {
+    const result = await validatorsInfo(near, epochId);
+    const seatPrice = validators.findSeatPrice(result.current_validators, result.numSeats);
+    result.current_validators = result.current_validators.sort((a, b) => -new BN(a.stake).cmp(new BN(b.stake)));
+    var validatorsTable = new AsciiTable();
+    validatorsTable.setHeading('Validator Id', 'Stake', '# seats', '% online', 'bls produced', 'bls expected');
+    console.log(`Validators (total: ${result.current_validators.length}, seat price: ${utils.format.formatNearAmount(seatPrice, 0)}):`);
+    result.current_validators.forEach((validator) => {
+        validatorsTable.addRow(
+            validator.account_id,
+            utils.format.formatNearAmount(validator.stake, 0),
+            new BN(validator.stake).divRound(seatPrice),
+            Math.floor(validator.num_produced_blocks / validator.num_expected_blocks * 100),
+            validator.num_produced_blocks,
+            validator.num_expected_blocks);
+    });
+    console.log(validatorsTable.toString());
+}
+
+async function showNextValidatorsTable(near) {
+    const result = await validatorsInfo(near, null);
+    const nextSeatPrice = validators.findSeatPrice(result.next_validators, result.numSeats);
+    const diff = validators.diffEpochValidators(result.current_validators, result.next_validators);
+    console.log(`\nNext validators (total: ${result.next_validators.length}, seat price: ${utils.format.formatNearAmount(nextSeatPrice, 0)}):`);
+    let nextValidatorsTable = new AsciiTable();
+    nextValidatorsTable.setHeading('Status', 'Validator', 'Stake', '# seats');
+    diff.newValidators.forEach((validator) => nextValidatorsTable.addRow(
+        'New',
+        validator.account_id,
+        utils.format.formatNearAmount(validator.stake, 0),
+        new BN(validator.stake).divRound(nextSeatPrice)));
+    diff.changedValidators.forEach((changeValidator) => nextValidatorsTable.addRow(
+        'Rewarded', 
+        changeValidator.next.account_id, 
+        `${utils.format.formatNearAmount(changeValidator.current.stake, 0)} -> ${utils.format.formatNearAmount(changeValidator.next.stake, 0)}`,
+        new BN(changeValidator.next.stake).divRound(nextSeatPrice)));
+    diff.removedValidators.forEach((validator) => nextValidatorsTable.addRow('Kicked out', validator.account_id, '-', '-'));
+    console.log(nextValidatorsTable.toString());
+}
+
+function combineValidatorsAndProposals(validators, proposalsMap) {
+    // TODO: filter out all kicked out validators.
+    let result = validators.filter((validator) => !proposalsMap.has(validator.account_id));
+    return result.concat([...proposalsMap.values()]);
+}
+
+async function showProposalsTable(near) {
+    const result = await validatorsInfo(near, null);
+    let currentValidators = new Map();
+    result.current_validators.forEach((v) => currentValidators.set(v.account_id, v));
+    let proposals = new Map();
+    result.current_proposals.forEach((p) => proposals.set(p.account_id, p));
+    const combinedProposals = combineValidatorsAndProposals(result.current_validators, proposals);
+    const expectedSeatPrice = validators.findSeatPrice(combinedProposals, result.numSeats);
+    console.log(`Proposals (total: ${proposals.size})`);
+    console.log(`Expected seat price = ${utils.format.formatNearAmount(expectedSeatPrice, 0)}`);
+    const proposalsTable = new AsciiTable();
+    combinedProposals.sort((a, b) => -new BN(a.stake).cmp(new BN(b.stake))).forEach((proposal) => {
+        let kind = '';
+        if (new BN(proposal.stake).gte(expectedSeatPrice)) {
+            kind = proposals.has(proposal.account_id) ? 'New' : 'Rollover';
+        } else {
+            kind = proposals.has(proposal.account_id) ? 'Declined' : 'Kicked out';
+        }
+        let stake_fmt = utils.format.formatNearAmount(proposal.stake, 0);
+        if (currentValidators.has(proposal.account_id) && proposals.has(proposal.account_id)) {
+            stake_fmt = `${utils.format.formatNearAmount(currentValidators.get(proposal.account_id).stake, 0)} => ${stake_fmt}`;
+        }
+        proposalsTable.addRow(
+            kind,
+            proposal.account_id,
+            stake_fmt
+        );
+    });
+    console.log(proposalsTable.toString());
+    console.log("Note: this currently doesn't account for offline kickouts and rewards for current epoch");
+}
+
+module.exports = { showValidatorsTable, showNextValidatorsTable, showProposalsTable };

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,6 +687,11 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
+ascii-table@0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/ascii-table/-/ascii-table-0.0.9.tgz#06a6604d6a55d4bf41a9a47d9872d7a78da31e73"
+  integrity sha1-BqZgTWpV1L9BqaR9mHLXp42jHnM=
+
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -816,7 +821,7 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bn.js@^5.0.0:
+bn.js@^5.0.0, bn.js@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.1.tgz#48efc4031a9c4041b9c99c6941d903463ab62eb5"
   integrity sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3245,9 +3245,10 @@ ncp@^2.0.0:
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
-"near-api-js@git+https://github.com/near/near-api-js.git":
-  version "0.23.2"
-  resolved "git+https://github.com/near/near-api-js.git#db51150b98f3e55c2893a410ad8e2379c10d8b73"
+near-api-js@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-0.24.0.tgz#99b19200748cdd6003c55c413e73e3903ce503c0"
+  integrity sha512-SxTiKlLYDcqbBQP/UVqm5bYd5SwPIpHgFvUT8PbO4rZ3z58Ws7wI1IQ/fganmzKOIFpKwvO5kjfs5j73qHCD1Q==
   dependencies:
     "@types/bn.js" "^4.11.5"
     bn.js "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3245,10 +3245,9 @@ ncp@^2.0.0:
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
-near-api-js@^0.23.1:
+"near-api-js@git+https://github.com/near/near-api-js.git":
   version "0.23.2"
-  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-0.23.2.tgz#649987cc516ac3d7d433879b5ba4e2378407cc13"
-  integrity sha512-cTldfMCI0fSaoPolRgMAKbQ4qBx4CXfM2MMUYbM7sce9l9IIUjm3BkKg1Kgdhhie07QAd8iuWMst10zArlK2FQ==
+  resolved "git+https://github.com/near/near-api-js.git#db51150b98f3e55c2893a410ad8e2379c10d8b73"
   dependencies:
     "@types/bn.js" "^4.11.5"
     bn.js "^5.0.0"


### PR DESCRIPTION
Ref #188 

Command:
```
near validators current
```

Current output:
```
Validators (total: 54, seat price: 51,205):
.------------------------------------------------------------------------------------.
|     Validator Id      |  Stake  | # seats | % online | bls produced | bls expected |
|-----------------------|---------|---------|----------|--------------|--------------|
| node3                 | 304,940 | 6       |      100 |          360 |          360 |
| node1                 | 304,924 | 6       |      100 |          361 |          361 |
| node0                 | 304,903 | 6       |      100 |          362 |          362 |
| node2                 | 277,171 | 5       |      100 |          361 |          361 |
| huglester.betanet     | 209,874 | 4       |      100 |          288 |          288 |
| hashquark             | 166,381 | 3       |      100 |          217 |          217 |
| unknown.test          | 137,481 | 3       |      100 |          144 |          144 |
| nuc2.test             | 110,512 | 2       |      100 |          145 |          145 |
| fredrikmalmqvist.test | 109,606 | 2       |       99 |          144 |          145 |
| dochpryof.test        | 109,566 | 2       |      100 |          144 |          144 |
| launooskuarttu.test   | 109,159 | 2       |      100 |          145 |          145 |
| janliamnilsson.test   | 108,907 | 2       |       99 |          143 |          144 |
| olaiolsen.test        | 108,806 | 2       |       99 |          144 |          145 |
| bowen.test            | 108,779 | 2       |      100 |          145 |          145 |
| tommywesley.test      | 108,583 | 2       |       98 |          143 |          145 |
| simonhugo.test        | 108,081 | 2       |      100 |          145 |          145 |
| oligarr.test          | 107,980 | 2       |      100 |          144 |          144 |
| felixschulz.test      | 107,478 | 2       |       75 |          109 |          145 |
| staked.test           | 107,033 | 2       |      100 |          144 |          144 |
| bitoven.test          | 106,765 | 2       |      100 |          144 |          144 |
| volvos60909.test      | 105,928 | 2       |      100 |          145 |          145 |
| jaroslavrud.test      | 105,579 | 2       |       59 |           86 |          144 |
| anonstake.test        | 105,525 | 2       |      100 |          144 |          144 |
| isillien.betanet      | 105,093 | 2       |      100 |          145 |          145 |
| pony.test             | 104,468 | 2       |      100 |          145 |          145 |
| buster.betanet        | 104,146 | 2       |      100 |          145 |          145 |
| pathrock.test         | 103,716 | 2       |      100 |          145 |          145 |
| gunray.test           | 102,611 | 2       |      100 |          145 |          145 |
| validatorsonline.test | 102,459 | 2       |      100 |          145 |          145 |
| andreyvelde.test      | 102,415 | 2       |      100 |          144 |          144 |
| unicorn.betanet       | 102,410 | 2       |      100 |          145 |          145 |
| nodeasy.test          | 102,179 | 2       |      100 |           72 |           72 |
| catcatcat.test        | 101,628 | 2       |      100 |           72 |           72 |
| danil.betanet         | 101,005 | 2       |      100 |           73 |           73 |
| zav.betanet           | 100,958 | 2       |      100 |           72 |           72 |
| sll.betanet           | 100,902 | 2       |      100 |           72 |           72 |
| fattox.test           | 100,721 | 2       |      100 |           72 |           72 |
| gaia.test             | 100,721 | 2       |        0 |            0 |           72 |
| stateb.betanet        | 100,717 | 2       |      100 |           72 |           72 |
| sparkpool.test        | 100,596 | 2       |      100 |           72 |           72 |
| moonlet.test          | 100,595 | 2       |      100 |           72 |           72 |
| afi.betanet           | 100,500 | 2       |      100 |           73 |           73 |
| fra.betanet           | 100,500 | 2       |      100 |           72 |           72 |
| max.betanet           | 100,500 | 2       |      100 |           72 |           72 |
| itokenpool.betanet    | 100,402 | 2       |      100 |           73 |           73 |
| harrypotter           | 100,304 | 2       |      100 |           72 |           72 |
| gladba.betanet        | 89,290  | 2       |      100 |           72 |           72 |
| ubikcapital.test      | 85,260  | 2       |      100 |           72 |           72 |
| lxyw.betanet          | 75,730  | 1       |      100 |           72 |           72 |
| zavodil.betanet       | 75,564  | 1       |      100 |           72 |           72 |
| something.betanet     | 75,229  | 1       |      100 |           72 |           72 |
| gamah.betanet         | 75,197  | 1       |        0 |            0 |           72 |
| vitalpointai.betanet  | 70,032  | 1       |      100 |           72 |           72 |
| blaze.betanet         | 55,168  | 1       |      100 |           72 |           72 |
'------------------------------------------------------------------------------------'
```

```
near validators next
```

Output:
```
Next validators (total: 54, seat price: 51,112):
.-------------------------------------------------------------------.
|   Status   |       Validator       |       Stake        | # seats |
|------------|-----------------------|--------------------|---------|
| New        | c1.nearkat            | 80,206             | 2       |
| New        | c29r3.betanet         | 100,499            | 2       |
| New        | kokos.betanet         | 100,000            | 2       |
| Rewarded   | afi.betanet           | 100,500 -> 100,545 | 2       |
| Rewarded   | andreyvelde.test      | 102,415 -> 102,460 | 2       |
| Rewarded   | anonstake.test        | 105,525 -> 105,572 | 2       |
| Rewarded   | bitoven.test          | 106,765 -> 106,812 | 2       |
| Rewarded   | blaze.betanet         | 55,168 -> 55,192   | 1       |
| Rewarded   | bowen.test            | 108,779 -> 108,827 | 2       |
| Rewarded   | buster.betanet        | 104,146 -> 104,192 | 2       |
| Rewarded   | catcatcat.test        | 101,628 -> 101,673 | 2       |
| Rewarded   | danil.betanet         | 101,005 -> 101,050 | 2       |
| Rewarded   | dochpryof.test        | 109,566 -> 109,614 | 2       |
| Rewarded   | fattox.test           | 100,721 -> 100,766 | 2       |
| Rewarded   | felixschulz.test      | 107,478 -> 107,525 | 2       |
| Rewarded   | fra.betanet           | 100,500 -> 100,545 | 2       |
| Rewarded   | fredrikmalmqvist.test | 109,606 -> 109,655 | 2       |
| Rewarded   | gladba.betanet        | 89,290 -> 89,330   | 2       |
| Rewarded   | gunray.test           | 102,611 -> 102,656 | 2       |
| Rewarded   | harrypotter           | 100,304 -> 100,348 | 2       |
| Rewarded   | hashquark             | 166,381 -> 166,455 | 3       |
| Rewarded   | huglester.betanet     | 209,874 -> 209,967 | 4       |
| Rewarded   | isillien.betanet      | 105,093 -> 105,140 | 2       |
| Rewarded   | itokenpool.betanet    | 100,402 -> 100,447 | 2       |
| Rewarded   | janliamnilsson.test   | 108,907 -> 108,955 | 2       |
| Rewarded   | launooskuarttu.test   | 109,159 -> 109,207 | 2       |
| Rewarded   | lxyw.betanet          | 75,730 -> 75,763   | 1       |
| Rewarded   | max.betanet           | 100,500 -> 100,545 | 2       |
| Rewarded   | moonlet.test          | 100,595 -> 100,640 | 2       |
| Rewarded   | node0                 | 304,903 -> 305,037 | 6       |
| Rewarded   | node1                 | 304,924 -> 305,058 | 6       |
| Rewarded   | node2                 | 277,171 -> 277,294 | 5       |
| Rewarded   | node3                 | 304,940 -> 305,074 | 6       |
| Rewarded   | nodeasy.test          | 102,179 -> 102,224 | 2       |
| Rewarded   | nuc2.test             | 110,512 -> 110,561 | 2       |
| Rewarded   | olaiolsen.test        | 108,806 -> 108,854 | 2       |
| Rewarded   | oligarr.test          | 107,980 -> 108,028 | 2       |
| Rewarded   | pathrock.test         | 103,716 -> 103,762 | 2       |
| Rewarded   | pony.test             | 104,468 -> 104,514 | 2       |
| Rewarded   | simonhugo.test        | 108,081 -> 108,129 | 2       |
| Rewarded   | sll.betanet           | 100,902 -> 100,947 | 2       |
| Rewarded   | something.betanet     | 75,229 -> 75,262   | 1       |
| Rewarded   | sparkpool.test        | 100,596 -> 100,640 | 2       |
| Rewarded   | staked.test           | 107,033 -> 107,080 | 2       |
| Rewarded   | stateb.betanet        | 100,717 -> 100,762 | 2       |
| Rewarded   | tommywesley.test      | 108,583 -> 108,631 | 2       |
| Rewarded   | ubikcapital.test      | 85,260 -> 85,297   | 2       |
| Rewarded   | unicorn.betanet       | 102,410 -> 102,456 | 2       |
| Rewarded   | unknown.test          | 137,481 -> 137,542 | 3       |
| Rewarded   | validatorsonline.test | 102,459 -> 102,504 | 2       |
| Rewarded   | vitalpointai.betanet  | 70,032 -> 70,062   | 1       |
| Rewarded   | volvos60909.test      | 105,928 -> 105,974 | 2       |
| Rewarded   | zav.betanet           | 100,958 -> 101,003 | 2       |
| Rewarded   | zavodil.betanet       | 75,564 -> 75,597   | 1       |
| Kicked out | gaia.test             | -                  | -       |
| Kicked out | gamah.betanet         | -                  | -       |
| Kicked out | jaroslavrud.test      | -                  | -       |
'-------------------------------------------------------------------'
```

```
near proposals
```

Output:
```
Proposals for the epoch after next (total: 6, expected seat price = 52,234)
.-----------------------------------------------------------------.
|       Status       |       Validator       | Stake => New Stake |
|--------------------|-----------------------|--------------------|
| Rollover           | node3                 | 304,940            |
| Rollover           | node1                 | 304,924            |
| Rollover           | node0                 | 304,903            |
| Rollover           | node2                 | 277,171            |
| Rollover           | huglester.betanet     | 209,874            |
| Rollover           | hashquark             | 166,381            |
| Proposal(Accepted) | unknown.test          | 137,481 => 165,985 |
| Rollover           | nuc2.test             | 110,512            |
| Rollover           | fredrikmalmqvist.test | 109,606            |
| Rollover           | dochpryof.test        | 109,566            |
| Proposal(Accepted) | ractolechoc5.test     | 109,296            |
| Rollover           | launooskuarttu.test   | 109,159            |
| Proposal(Accepted) | villiamsivertsen.test | 108,964            |
| Rollover           | janliamnilsson.test   | 108,907            |
| Rollover           | olaiolsen.test        | 108,806            |
| Rollover           | bowen.test            | 108,779            |
| Rollover           | tommywesley.test      | 108,583            |
| Rollover           | simonhugo.test        | 108,081            |
| Rollover           | oligarr.test          | 107,980            |
| Rollover           | felixschulz.test      | 107,478            |
| Rollover           | staked.test           | 107,033            |
| Rollover           | bitoven.test          | 106,765            |
| Rollover           | volvos60909.test      | 105,928            |
| Rollover           | jaroslavrud.test      | 105,579            |
| Rollover           | anonstake.test        | 105,525            |
| Rollover           | isillien.betanet      | 105,093            |
| Rollover           | pony.test             | 104,468            |
| Rollover           | buster.betanet        | 104,146            |
| Rollover           | pathrock.test         | 103,716            |
| Rollover           | gunray.test           | 102,611            |
| Rollover           | validatorsonline.test | 102,459            |
| Rollover           | andreyvelde.test      | 102,415            |
| Rollover           | unicorn.betanet       | 102,410            |
| Rollover           | nodeasy.test          | 102,179            |
| Rollover           | catcatcat.test        | 101,628            |
| Rollover           | danil.betanet         | 101,005            |
| Rollover           | zav.betanet           | 100,958            |
| Rollover           | sll.betanet           | 100,902            |
| Rollover           | fattox.test           | 100,721            |
| Rollover           | gaia.test             | 100,721            |
| Rollover           | stateb.betanet        | 100,717            |
| Rollover           | sparkpool.test        | 100,596            |
| Rollover           | moonlet.test          | 100,595            |
| Rollover           | afi.betanet           | 100,500            |
| Rollover           | fra.betanet           | 100,500            |
| Rollover           | max.betanet           | 100,500            |
| Rollover           | itokenpool.betanet    | 100,402            |
| Rollover           | harrypotter           | 100,304            |
| Proposal(Accepted) | stakingfund.test      | 100,000            |
| Rollover           | gladba.betanet        | 89,290             |
| Rollover           | ubikcapital.test      | 85,260             |
| Rollover           | lxyw.betanet          | 75,730             |
| Rollover           | zavodil.betanet       | 75,564             |
| Rollover           | something.betanet     | 75,229             |
| Rollover           | gamah.betanet         | 75,197             |
| Rollover           | vitalpointai.betanet  | 70,032             |
| Rollover           | blaze.betanet         | 55,168             |
| Proposal(Declined) | dokiacapital.betanet  | 11,133             |
| Proposal(Declined) | a.betanet             | 500                |
'-----------------------------------------------------------------'
Expected seat price is calculated based on observed so far proposals and validators.
It can change from new proposals or some validators going offline.
Note: this currently doesn't account for offline kickouts and rewards for current epoch
```

<a href="https://gitpod.io/#https://github.com/nearprotocol/near-shell/pull/328"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nearprotocol/near-shell.git/e9c7986ecce284a416c695b044fb5754b1f9da55.svg" /></a>
