### PR TITLE
use subaccounts and provide suggestions, fix tests

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -176,6 +176,11 @@ yargs // eslint-disable-line
         type: 'string',
         hidden: true
     })
+    .option('tla', {
+        desc: 'Expected top-level account for a network',
+        type: 'string',
+        hidden: true
+    })
     .middleware(require('../middleware/initial-balance'))
     .middleware(require('../middleware/print-options'))
     .middleware(require('../middleware/key-store'))

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -176,7 +176,7 @@ yargs // eslint-disable-line
         desc: 'Master account used when creating new accounts',
         type: 'string'
     })
-    .option('tla', {
+    .option('helperAccount', {
         desc: 'Expected top-level account for a network',
         type: 'string'
     })

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -160,26 +160,21 @@ yargs // eslint-disable-line
         desc: 'Unique identifier for the account',
         type: 'string',
     })
-
     .option('walletUrl', {
         desc: 'Website for NEAR Wallet',
-        type: 'string',
-        hidden: true
+        type: 'string'
     })
     .option('contractName', {
         desc: 'Account name of contract',
-        type: 'string',
-        hidden: true
+        type: 'string'
     })
     .option('masterAccount', {
         desc: 'Master account used when creating new accounts',
-        type: 'string',
-        hidden: true
+        type: 'string'
     })
     .option('tla', {
         desc: 'Expected top-level account for a network',
-        type: 'string',
-        hidden: true
+        type: 'string'
     })
     .middleware(require('../middleware/initial-balance'))
     .middleware(require('../middleware/print-options'))

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -3,10 +3,18 @@ const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const { KeyPair } = require('near-api-js');
 const eventtracking = require('../utils/eventtracking');
+const NEAR_ENV_SUFFIXES = {
+    production: 'near',
+    default: 'testnet',
+    development: 'testnet',
+    devnet: 'devnet',
+    betanet: 'betanet'
+};
+const TLA_MIN_LENGTH = 32;
 
 module.exports = {
     command: 'create_account <accountId>',
-    desc: 'create a new developer account',
+    desc: 'create a new developer account (subaccount of the masterAccount, ex: app.alice.test)',
     builder: (yargs) => yargs
         .option('accountId', {
             desc: 'Unique identifier for the newly created account',
@@ -34,6 +42,39 @@ module.exports = {
 async function createAccount(options) {
     await eventtracking.track(eventtracking.EVENT_ID_CREATE_ACCOUNT_START, { nodeUrl: options.nodeUrl });
     // NOTE: initialBalance is passed as part of config here, parsed in middleware/initial-balance
+    // periods are disallowed in top-level accounts and can only be used for subaccounts
+    const splitAccount = options.accountId.split('.');
+
+    const splitMaster = options.masterAccount.split('.');
+    const masterRootTLA = splitMaster[splitMaster.length - 1];
+    if (splitAccount.length === 1) {
+        // TLA (bob-with-at-least-maximum-characters)
+        if (splitAccount[0].length < TLA_MIN_LENGTH) {
+            console.log(`Top-level accounts must be greater than ${TLA_MIN_LENGTH} characters.\n` +
+              'Note: this is for advanced usage only. Typical account names are of the form:\n' +
+              'app.alice.test, where the masterAccount shares the top-level account (.test).'
+            );
+            return;
+        }
+    } else if (splitAccount.length > 1) {
+        // Subaccounts (short.alice.near, even.more.bob.test, and eventually peter.potato)
+        // Check that master account TLA matches
+        const accountRootTLA = splitAccount[splitAccount.length - 1];
+        const accountTLA = splitAccount.filter((n, i) => i !== 0).join('.');
+        if (accountTLA !== options.masterAccount) {
+            console.log(`New account doesn't share the same top-level account. Expecting account name to end in ".${options.masterAccount}"`);
+            return;
+        }
+
+        // Rules apply for environments except local, test, ci, ci-staging
+        if (Object.keys(NEAR_ENV_SUFFIXES).includes(options.networkId)) {
+            // Recommend that the TLA matches the expected network in most cases
+            const networkTLA = NEAR_ENV_SUFFIXES[options.networkId];
+            if (networkTLA !== masterRootTLA || networkTLA !== accountRootTLA) {
+                console.log(`NOTE: In most cases, when connected to "${options.networkId}" account and masterAccount will end in ".${networkTLA}"`);
+            }
+        }
+    }
     let near = await connect(options);
     let keyPair;
     let publicKey;

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -49,7 +49,7 @@ async function createAccount(options) {
     if (splitAccount.length === 1) {
         // TLA (bob-with-at-least-maximum-characters)
         if (splitAccount[0].length < TLA_MIN_LENGTH) {
-            console.log(`Top-level accounts must be greater than ${TLA_MIN_LENGTH} characters.\n` +
+            console.log(`Top-level accounts must be at least ${TLA_MIN_LENGTH} characters.\n` +
               'Note: this is for advanced usage only. Typical account names are of the form:\n' +
               'app.alice.test, where the masterAccount shares the top-level account (.test).'
             );
@@ -58,15 +58,16 @@ async function createAccount(options) {
     } else if (splitAccount.length > 1) {
         // Subaccounts (short.alice.near, even.more.bob.test, and eventually peter.potato)
         // Check that master account TLA matches
-        const accountTLA = splitAccount.filter((n, i) => i !== 0).join('.');
-        if (accountTLA !== options.masterAccount) {
+        if (!options.accountId.endsWith(`.${options.masterAccount}`)) {
             console.log(`New account doesn't share the same top-level account. Expecting account name to end in ".${options.masterAccount}"`);
             return;
         }
 
         // Warn user if account seems to be using wrong network, where TLA is captured in config
-        if (Object.prototype.hasOwnProperty.call(options, 'tla') && masterRootTLA !== options.tla) {
-            console.log(`NOTE: In most cases, when connected to network "${options.networkId}", masterAccount will end in ".${options.tla}"`);
+        // TODO: when "network" key is available, revisit logic to determine if user is on proper network
+        // See: https://github.com/near/near-shell/issues/387
+        if (options.helperAccount && masterRootTLA !== options.helperAccount) {
+            console.log(`NOTE: In most cases, when connected to network "${options.networkId}", masterAccount will end in ".${options.helperAccount}"`);
         }
     }
     let near = await connect(options);

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -50,7 +50,7 @@ async function devDeploy(options) {
     await eventtracking.track(eventtracking.EVENT_ID_DEV_DEPLOY_END, { node: options.nodeUrl, success: true });
 }
 
-async function createDevAccountIfNeeded({ near, keyStore, networkId, init, masterAccount, helperUrl }) {
+async function createDevAccountIfNeeded({ near, keyStore, networkId, init, masterAccount, helperUrl, tla }) {
     // TODO: once examples and create-near-app use the dev-account.env file, we can remove the creation of dev-account
     // https://github.com/nearprotocol/near-shell/issues/287
     const accountFilePath = `${PROJECT_KEY_DIR}/dev-account`;
@@ -75,12 +75,12 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init, maste
         }
     }
     let accountId;
-    if (typeof masterAccount === 'undefined' && helperUrl) {
-        // determine "faucet" account name of environment from helperUrl
-        const splitHelper = helperUrl.split('.');
-        accountId = `dev-${Date.now()}.${splitHelper[1]}`;
-    } else {
+    if (typeof masterAccount === 'undefined' && helperUrl && tla) {
+        accountId = `dev-${Date.now()}.${tla}`;
+    } else if (masterAccount) {
         accountId = `dev-${Date.now()}.${masterAccount}`;
+    } else {
+        console.error('Expecting helperUrl and/or tla flag, please provide those.');
     }
 
     const keyPair = await KeyPair.fromRandom('ed25519');

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -51,7 +51,7 @@ async function devDeploy(options) {
     await eventtracking.track(eventtracking.EVENT_ID_DEV_DEPLOY_END, { node: options.nodeUrl, success: true });
 }
 
-async function createDevAccountIfNeeded({ near, keyStore, networkId, init, masterAccount, helperUrl, helperAccount }) {
+async function createDevAccountIfNeeded({ near, keyStore, networkId, init, masterAccount }) {
     // TODO: once examples and create-near-app use the dev-account.env file, we can remove the creation of dev-account
     // https://github.com/nearprotocol/near-shell/issues/287
     const accountFilePath = `${PROJECT_KEY_DIR}/dev-account`;
@@ -76,12 +76,13 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init, maste
         }
     }
     let accountId;
-    if (typeof masterAccount === 'undefined' && helperUrl && helperAccount) {
-        accountId = `dev-${Date.now()}.${helperAccount}`;
-    } else if (masterAccount) {
+    // create random number with at least 7 digits
+    const randomNumber = Math.floor(Math.random() * (9999999 - 1000000) + 1000000);
+
+    if (masterAccount) {
         accountId = `dev-${Date.now()}.${masterAccount}`;
     } else {
-        console.error('Expecting helperUrl and/or helperAccount flag, please provide those.');
+        accountId = `dev-${Date.now()}-${randomNumber}`;
     }
 
     const keyPair = await KeyPair.fromRandom('ed25519');

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -48,7 +48,7 @@ async function devDeploy(options) {
     await eventtracking.track(eventtracking.EVENT_ID_DEV_DEPLOY_END, { node: options.nodeUrl, success: true });
 }
 
-async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
+async function createDevAccountIfNeeded({ near, keyStore, networkId, init, masterAccount, helperUrl }) {
     // TODO: once examples and create-near-app use the dev-account.env file, we can remove the creation of dev-account
     // https://github.com/nearprotocol/near-shell/issues/287
     const accountFilePath = `${keyStore.keyDir}/dev-account`;
@@ -69,8 +69,15 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
             }
         }
     }
+    let accountId;
+    if (typeof masterAccount === 'undefined' && helperUrl) {
+        // determine "faucet" account name of environment from helperUrl
+        const splitHelper = helperUrl.split('.');
+        accountId = `dev-${Date.now()}.${splitHelper[1]}`;
+    } else {
+        accountId = `dev-${Date.now()}.${masterAccount}`;
+    }
 
-    const accountId = `dev-${Date.now()}`;
     const keyPair = await KeyPair.fromRandom('ed25519');
     await near.accountCreator.createAccount(accountId, keyPair.publicKey);
     await keyStore.setKey(networkId, accountId, keyPair);

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -51,7 +51,7 @@ async function devDeploy(options) {
     await eventtracking.track(eventtracking.EVENT_ID_DEV_DEPLOY_END, { node: options.nodeUrl, success: true });
 }
 
-async function createDevAccountIfNeeded({ near, keyStore, networkId, init, masterAccount, helperUrl, tla }) {
+async function createDevAccountIfNeeded({ near, keyStore, networkId, init, masterAccount, helperUrl, helperAccount }) {
     // TODO: once examples and create-near-app use the dev-account.env file, we can remove the creation of dev-account
     // https://github.com/nearprotocol/near-shell/issues/287
     const accountFilePath = `${PROJECT_KEY_DIR}/dev-account`;
@@ -76,12 +76,12 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init, maste
         }
     }
     let accountId;
-    if (typeof masterAccount === 'undefined' && helperUrl && tla) {
-        accountId = `dev-${Date.now()}.${tla}`;
+    if (typeof masterAccount === 'undefined' && helperUrl && helperAccount) {
+        accountId = `dev-${Date.now()}.${helperAccount}`;
     } else if (masterAccount) {
         accountId = `dev-${Date.now()}.${masterAccount}`;
     } else {
-        console.error('Expecting helperUrl and/or tla flag, please provide those.');
+        console.error('Expecting helperUrl and/or helperAccount flag, please provide those.');
     }
 
     const keyPair = await KeyPair.fromRandom('ed25519');

--- a/config.js
+++ b/config.js
@@ -11,6 +11,7 @@ function getConfig(env) {
             contractName: CONTRACT_NAME,
             walletUrl: 'https://wallet.near.org',
             helperUrl: 'https://helper.mainnet.near.org',
+            tla: 'near',
         };
     case 'development':
     case 'testnet':
@@ -20,6 +21,7 @@ function getConfig(env) {
             contractName: CONTRACT_NAME,
             walletUrl: 'https://wallet.testnet.near.org',
             helperUrl: 'https://helper.testnet.near.org',
+            tla: 'testnet',
         };
     case 'devnet':
         return {
@@ -28,6 +30,7 @@ function getConfig(env) {
             contractName: CONTRACT_NAME,
             walletUrl: 'https://wallet.devnet.near.org',
             helperUrl: 'https://helper.devnet.near.org',
+            tla: 'devnet',
         };
     case 'betanet':
         return {
@@ -36,6 +39,7 @@ function getConfig(env) {
             contractName: CONTRACT_NAME,
             walletUrl: 'https://wallet.betanet.near.org',
             helperUrl: 'https://helper.betanet.near.org',
+            tla: 'betanet',
         };
     case 'local':
         return {

--- a/config.js
+++ b/config.js
@@ -11,7 +11,7 @@ function getConfig(env) {
             contractName: CONTRACT_NAME,
             walletUrl: 'https://wallet.near.org',
             helperUrl: 'https://helper.mainnet.near.org',
-            tla: 'near',
+            helperAccount: 'near',
         };
     case 'development':
     case 'testnet':
@@ -21,7 +21,7 @@ function getConfig(env) {
             contractName: CONTRACT_NAME,
             walletUrl: 'https://wallet.testnet.near.org',
             helperUrl: 'https://helper.testnet.near.org',
-            tla: 'testnet',
+            helperAccount: 'testnet',
         };
     case 'devnet':
         return {
@@ -30,7 +30,7 @@ function getConfig(env) {
             contractName: CONTRACT_NAME,
             walletUrl: 'https://wallet.devnet.near.org',
             helperUrl: 'https://helper.devnet.near.org',
-            tla: 'devnet',
+            helperAccount: 'devnet',
         };
     case 'betanet':
         return {
@@ -39,7 +39,7 @@ function getConfig(env) {
             contractName: CONTRACT_NAME,
             walletUrl: 'https://wallet.betanet.near.org',
             helperUrl: 'https://helper.betanet.near.org',
-            tla: 'betanet',
+            helperAccount: 'betanet',
         };
     case 'local':
         return {

--- a/test/test_account_creation.sh
+++ b/test/test_account_creation.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+timestamp=$(date +%s)
+testaccount=testaccount$timestamp.test.near
+
+RESULT=$(./bin/near create_account $testaccount --masterAccount test.far)
+echo $RESULT
+EXPECTED=".+New account doesn't share the same top-level account.+ "
+if [[ ! "$RESULT" =~ $EXPECTED ]]; then
+    echo FAILURE Unexpected output from near view
+    exit 1
+fi
+
+RESULT=$(./bin/near create_account tooshortfortla)
+echo $RESULT
+EXPECTED=".+Top-level accounts must be at least.+ "
+if [[ ! "$RESULT" =~ $EXPECTED ]]; then
+    echo FAILURE Unexpected output from near view
+    exit 1
+fi

--- a/test/test_account_operations.sh
+++ b/test/test_account_operations.sh
@@ -4,12 +4,12 @@ rm  -rf tmp-project
 yarn create near-app --vanilla tmp-project
 cd tmp-project
 timestamp=$(date +%s)
-testaccount=testaccount$timestamp
+testaccount=testaccount$timestamp.test.near
 echo Create account
 ../bin/near create_account $testaccount
 
 echo Get account state
-RESULT=$(../bin/near state $testaccount | strip-ansi)
+RESULT=$(../bin/near state $testaccount | ../node_modules/.bin/strip-ansi)
 echo $RESULT
 EXPECTED=".+Account $testaccount.+amount:.+'100000000000000000000000000'.+ "
 if [[ ! "$RESULT" =~ $EXPECTED ]]; then

--- a/test/test_contract.sh
+++ b/test/test_contract.sh
@@ -7,7 +7,7 @@ yarn create near-app --vanilla tmp-project
 cd tmp-project
 
 timestamp=$(date +%s)
-testaccount=testaccount$timestamp
+testaccount=testaccount$timestamp.test.near
 ../bin/near create_account $testaccount
 
 echo Building contract

--- a/test_environment.js
+++ b/test_environment.js
@@ -18,9 +18,12 @@ class LocalTestEnvironment extends NodeEnvironment {
         this.global.window = {};
         let config = require('./get-config')();
         this.global.testSettings = this.global.nearConfig = config;
+        const now = Date.now();
+        // create random number with at least 7 digits
+        const randomNumber = Math.floor(Math.random() * (9999999 - 1000000) + 1000000);
         config = Object.assign(config, {
-            contractName: 'test' + Date.now(),
-            accountId: 'test' + Date.now()
+            contractName: 'test-account-' + now + '-' + randomNumber,
+            accountId: 'test-account-' + now + '-' + randomNumber
         });
         const keyStore = new nearAPI.keyStores.UnencryptedFileSystemKeyStore(PROJECT_KEY_DIR);
         config.deps = Object.assign(config.deps || {}, {


### PR DESCRIPTION
(Needed to make a fresh branch)
Second attempt at issue:
https://github.com/nearprotocol/near-shell/issues/307

First attempt was here:
https://github.com/nearprotocol/near-shell/pull/324

It was my mistake in not testing it properly and we reverted that PR.

The new item here is during dev-deploy, we check to see what environment the user is on (betanet, testnet, etc) and if it's using a `helperUrl` determine what the name of the account is that'll be funding the creation. So we split the `helperUrl`. Basically a newly created account can either be from a `masterAccount` or from a `helperUrl` and we need to determine what the account suffix will be.

With the latest commit this kind of thing will work, when before it would fail:
`NODE_ENV=ci yarn near dev-deploy`
^ Note: I ran this in the `guest-book` example after I copy/pasted shell's `config.js` to guest-book's `src/config.js` so it knows about betanet and the new URLs.

So above is the new stuff.
I'll paste the description from the other PR, which is the old stuff:
This ended up being a bit of a compromise, knowing that long-term, we'll be allowing TLA's that are based on other chains' account addresses. Yet at the same time, we want to make clear to the end user that **most** of the time they'll want to approach account creation as subaccounts.

Here's a list of commands run and the results to demonstrate:
`./bin/near create_account hihihi --masterAccount asdf.test`
results in:

> Top-level accounts must be greater than 32 characters.
> Note: this is for advanced usage only. Typical account names are of the form:
> app.alice.test, where the masterAccount shares the top-level account (.test).
> 

`./bin/near create_account hihihiveryveryverylongnamethisisunusual --masterAccount asdf.test`
passes

`NODE_ENV=betanet ./bin/near create_account mike.asdf.test --masterAccount asdf.test`
passes but throws the message:

> NOTE: In most cases, when connected to "betanet", account and masterAccount will end in ".beta"

`./bin/near create_account mike.asdf.test --masterAccount asdf.test`
succeeds

`./bin/near create_account hi.mike.asdf.test --masterAccount mike.asdf.test`
succeeds

`./bin/near create_account hi.mike.asdf.test --masterAccount mike.asdf.purvis`
results in:

>New account doesn't share the same top-level account. Expecting account name to end in ".mike.asdf.purvis"

`./bin/near create_account hi.mike.asdf.purvis --masterAccount mike.asdf.test`
results in:

>New account doesn't share the same top-level account. Expecting account name to end in ".mike.asdf.test"

<a href="https://gitpod.io/#https://github.com/nearprotocol/near-shell/pull/331"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nearprotocol/near-shell.git/41b2c6773354e5037c4e1ca17ebec238242783ad.svg" /></a>

