### PR TITLE
refactor: replace nearprotocol.com with near.org

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at social@nearprotocol.com. All
+reported by contacting the project team at social@near.org. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to NEAR
 
 NEAR welcomes help in many forms including development, code review, documentation improvements, and outreach.
-Please visit [the contribution overview](https://docs.nearprotocol.com/docs/contribution/contribution-overview) for more information.
+Please visit [the contribution overview](https://docs.near.org/docs/contribution/contribution-overview) for more information.
 
 ## Using Github issues and pull requests
 
@@ -11,7 +11,7 @@ Please include steps to reproduction, if reporting an error. Information on all 
 
 If there are verbosity flags available, please include those to offer as much information as possible.
 
-When opening a pull request, please use the typical open-source flow of forking the desired repository and opening a pull request from your forked repository. (More information on [technical contributions here](https://docs.nearprotocol.com/docs/contribution/technical-contribution).)
+When opening a pull request, please use the typical open-source flow of forking the desired repository and opening a pull request from your forked repository. (More information on [technical contributions here](https://docs.near.org/docs/contribution/technical-contribution).)
 
 ## Testing
 

--- a/config.js
+++ b/config.js
@@ -9,7 +9,7 @@ function getConfig(env) {
             networkId: 'mainnet',
             nodeUrl: 'https://rpc.mainnet.near.org',
             contractName: CONTRACT_NAME,
-            walletUrl: 'https://wallet.mainnet.near.org',
+            walletUrl: 'https://wallet.near.org',
             helperUrl: 'https://helper.mainnet.near.org',
         };
     case 'development':

--- a/utils/capture-login-success.js
+++ b/utils/capture-login-success.js
@@ -94,7 +94,7 @@ module.exports = { payload, callback, cancel };
 function renderWebPage(message){
     const title = 'NEAR Account Authorization Success';
 
-    // logo and font from https://nearprotocol.com/brand/
+    // logo and font from https://near.org/brand/
     return `
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
We will keep both of these endpoints functional for a while, but we want to encourage people to start using the near.org endpoints. Once all of these `near.org` endpoints are live, let's merge this.

## To do

- [x] wait until https://github.com/near/devx/issues/154 is resolved (all `near.org` endpoints live) then re-run tests and make sure this works