### PR TITLE
Move default location for credentials to .near-credentials

### DIFF
--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -51,8 +51,9 @@ async function devDeploy(options) {
 async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
     // TODO: once examples and create-near-app use the dev-account.env file, we can remove the creation of dev-account
     // https://github.com/nearprotocol/near-shell/issues/287
-    const accountFilePath = `${keyStore.keyDir}/dev-account`;
-    const accountFilePathEnv = `${keyStore.keyDir}/dev-account.env`;
+    console.log(near)
+    const accountFilePath = `neardev/dev-account`;
+    const accountFilePathEnv = `neardev/dev-account.env`;
     if (!init) {
         try {
             // throws if either file is missing

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -51,9 +51,8 @@ async function devDeploy(options) {
 async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
     // TODO: once examples and create-near-app use the dev-account.env file, we can remove the creation of dev-account
     // https://github.com/nearprotocol/near-shell/issues/287
-    console.log(near)
-    const accountFilePath = `neardev/dev-account`;
-    const accountFilePathEnv = `neardev/dev-account.env`;
+    const accountFilePath = 'neardev/dev-account';
+    const accountFilePathEnv = 'neardev/dev-account.env';
     if (!init) {
         try {
             // throws if either file is missing

--- a/middleware/key-store.js
+++ b/middleware/key-store.js
@@ -1,8 +1,18 @@
 const nearlib = require('near-api-js');
+const homedir = require('os').homedir();
+const path = require('path');
+const MergeKeyStore = nearlib.keyStores.MergeKeyStore;
 const UnencryptedFileSystemKeyStore = nearlib.keyStores.UnencryptedFileSystemKeyStore;
 
+const CREDENTIALS_DIR = '.near-credentials';
+
 module.exports = async function createKeyStore() {
-    // TODO: Search for key store in multiple locations
-    // TODO: Use system key store if possible
-    return { keyStore: new UnencryptedFileSystemKeyStore('./neardev') };
+    // ./neardev is an old way of storing keys under project folder. We want to fallback there for backwards compatibility
+    const credentialsPath = path.join(homedir, CREDENTIALS_DIR);
+    console.log(credentialsPath);
+    const keyStores = [
+        new UnencryptedFileSystemKeyStore(credentialsPath),
+        new UnencryptedFileSystemKeyStore('./neardev')
+    ];
+    return { keyStore: new MergeKeyStore(keyStores) };
 };

--- a/middleware/key-store.js
+++ b/middleware/key-store.js
@@ -8,8 +8,9 @@ const CREDENTIALS_DIR = '.near-credentials';
 
 module.exports = async function createKeyStore() {
     // ./neardev is an old way of storing keys under project folder. We want to fallback there for backwards compatibility
+    // TODO: use system keystores.
+    // TODO: setting in config for which keystore to use
     const credentialsPath = path.join(homedir, CREDENTIALS_DIR);
-    console.log(credentialsPath);
     const keyStores = [
         new UnencryptedFileSystemKeyStore(credentialsPath),
         new UnencryptedFileSystemKeyStore('./neardev')

--- a/test/test_generate_key.sh
+++ b/test/test_generate_key.sh
@@ -1,7 +1,7 @@
 
 #!/bin/bash
 set -ex
-KEY_FILE=neardev/$NODE_ENV/generate-key-test.json
+KEY_FILE=.near-config/$NODE_ENV/generate-key-test.json
 rm -f "$KEY_FILE"
 
 RESULT=$(./bin/near generate-key generate-key-test --networkId $NODE_ENV)

--- a/test/test_generate_key.sh
+++ b/test/test_generate_key.sh
@@ -3,6 +3,7 @@
 set -ex
 KEY_FILE=~/.near-config/$NODE_ENV/generate-key-test.json
 rm -f "$KEY_FILE"
+echo "Testing generating-key: new key"
 
 RESULT=$(./bin/near generate-key generate-key-test --networkId $NODE_ENV)
 echo $RESULT
@@ -17,6 +18,8 @@ if [[ ! "$RESULT" =~ $EXPECTED ]]; then
     echo FAILURE Unexpected output from near generate-key
     exit 1
 fi
+
+echo "Testing generating-key: key for account already exists"
 
 RESULT2=$(./bin/near generate-key generate-key-test --networkId $NODE_ENV)
 echo $RESULT2

--- a/test/test_generate_key.sh
+++ b/test/test_generate_key.sh
@@ -1,7 +1,7 @@
 
 #!/bin/bash
 set -ex
-KEY_FILE=.near-config/$NODE_ENV/generate-key-test.json
+KEY_FILE=~/.near-config/$NODE_ENV/generate-key-test.json
 rm -f "$KEY_FILE"
 
 RESULT=$(./bin/near generate-key generate-key-test --networkId $NODE_ENV)

--- a/test/test_generate_key.sh
+++ b/test/test_generate_key.sh
@@ -1,7 +1,7 @@
 
 #!/bin/bash
 set -ex
-KEY_FILE=~/.near-config/$NODE_ENV/generate-key-test.json
+KEY_FILE=~/.near-credentials/$NODE_ENV/generate-key-test.json
 rm -f "$KEY_FILE"
 echo "Testing generating-key: new key"
 

--- a/utils/verify-account.js
+++ b/utils/verify-account.js
@@ -1,9 +1,6 @@
 // npm imports
 const chalk = require('chalk');
 
-// NEAR imports
-const { keyStores } = require('near-api-js');
-
 // local imports
 const connect = require('./connect');
 

--- a/utils/verify-account.js
+++ b/utils/verify-account.js
@@ -3,7 +3,6 @@ const chalk = require('chalk');
 
 // NEAR imports
 const { keyStores } = require('near-api-js');
-const UnencryptedFileSystemKeyStore = keyStores.UnencryptedFileSystemKeyStore;
 
 // local imports
 const connect = require('./connect');

--- a/utils/verify-account.js
+++ b/utils/verify-account.js
@@ -21,7 +21,7 @@ module.exports = async (accountId, keyPair, options) => {
             key => key.public_key == keyPair.getPublicKey().toString()
         );
         if (keyFound) {
-            const keyStore = new UnencryptedFileSystemKeyStore('./neardev');
+            const keyStore = near.config.deps.keyStore;
             await keyStore.setKey(options.networkId, accountId, keyPair);
             console.log(chalk`Logged in as [ {bold ${accountId}} ] with public key [ {bold ${short(publicKey)}} ] successfully\n`
             );


### PR DESCRIPTION
Also fix an issue that login is not honoring the system-wide keystore
and creating its own version.

The new location for keys is, for example on windows with default env: C:\Users\userid\.near-credentials\default 

<a href="https://gitpod.io/#https://github.com/nearprotocol/near-shell/pull/339"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nearprotocol/near-shell.git/f63ba3982b4c0db257f41292fce88e18f45a2fd0.svg" /></a>

