### PR TITLE
Disable callback url capture for windows as a temp workaround

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,13 +54,13 @@ exports.callViewFunction = async function (options) {
 };
 
 // open a given URL in browser in a safe way.
-openUrl = async function(url) {
+const openUrl = async function(url) {
     try {
         await open(url.toString());
     } catch (error) {
         console.error(`Failed to open the URL [ ${url.toString()} ]`, error);
     }
-}
+};
 
 exports.login = async function (options) {
     await eventtracking.track(eventtracking.EVENT_ID_LOGIN_START, { node: options.nodeUrl });
@@ -77,7 +77,7 @@ exports.login = async function (options) {
 
         // attempt to capture accountId automatically via browser callback
         let tempUrl;
-        const isWin = process.platform === "win32";
+        const isWin = process.platform === 'win32';
 
         // find a callback URL on the local machine
         try {

--- a/index.js
+++ b/index.js
@@ -53,6 +53,15 @@ exports.callViewFunction = async function (options) {
     await eventtracking.track(eventtracking.EVENT_ID_CALL_VIEW_FN_END, { node: options.nodeUrl, success: true });
 };
 
+openUrl = async function(url) {
+    try {
+        // open a browser to capture NEAR Wallet callback (and quietly direct the user if open fails)
+        await open(url.toString());
+    } catch (error) {
+        console.error(`Failed to open the URL [ ${url.toString()} ]`, error);
+    }
+}
+
 exports.login = async function (options) {
     await eventtracking.track(eventtracking.EVENT_ID_LOGIN_START, { node: options.nodeUrl });
     if (!options.walletUrl) {
@@ -68,10 +77,13 @@ exports.login = async function (options) {
 
         // attempt to capture accountId automatically via browser callback
         let tempUrl;
+        const isWin = process.platform === "win32";
 
         // find a callback URL on the local machine
         try {
-            tempUrl = await capture.callback(5000);
+            if (!isWin) { // capture callback is currently not working on windows. This is a workaround to not use it
+                tempUrl = await capture.callback(5000);
+            }
         } catch (error) {
             // console.error("Failed to find suitable port.", error.message)
             // TODO: Is it? Try triggering error
@@ -86,14 +98,10 @@ exports.login = async function (options) {
                 // Browser not opened, as will open automatically for opened port
             } else {
                 newUrl.searchParams.set('success_url', `http://${tempUrl.hostname}:${tempUrl.port}`);
-
-                try {
-                    // open a browser to capture NEAR Wallet callback (and quietly direct the user if open fails)
-                    await open(newUrl.toString());
-                } catch (error) {
-                    console.error(`Failed to open the URL [ ${newUrl.toString()} ]`, error);
-                }
+                openUrl(newUrl); 
             }
+        } else if (isWin) {
+            openUrl(newUrl);
         }
 
         console.log(chalk`\n{dim If your browser doesn't automatically open, please visit this URL\n${newUrl.toString()}}`);
@@ -108,12 +116,13 @@ exports.login = async function (options) {
             input: process.stdin,
             output: process.stdout
         });
+        const redirectAutomaticallyHint = tempUrl ? '(if not redirected automatically)' : '';
         const getAccountFromConsole = async () => {
             return await new Promise((resolve) => {
                 rl.question(
                     chalk`Please authorize at least one account at the URL above.\n\n` +
                     chalk`Which account did you authorize for use with NEAR Shell?\n` +
-                    chalk`{bold Enter it here (if not redirected automatically):}\n`, async (accountId) => {
+                    chalk`{bold Enter it here${redirectAutomaticallyHint}:}\n`, async (accountId) => {
                         resolve(accountId);
                     });
             });

--- a/index.js
+++ b/index.js
@@ -53,9 +53,9 @@ exports.callViewFunction = async function (options) {
     await eventtracking.track(eventtracking.EVENT_ID_CALL_VIEW_FN_END, { node: options.nodeUrl, success: true });
 };
 
+// open a given URL in browser in a safe way.
 openUrl = async function(url) {
     try {
-        // open a browser to capture NEAR Wallet callback (and quietly direct the user if open fails)
         await open(url.toString());
     } catch (error) {
         console.error(`Failed to open the URL [ ${url.toString()} ]`, error);
@@ -101,6 +101,7 @@ exports.login = async function (options) {
                 openUrl(newUrl); 
             }
         } else if (isWin) {
+            // redirect automatically on windows, but do not use the browser callback
             openUrl(newUrl);
         }
 

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ exports.login = async function (options) {
             input: process.stdin,
             output: process.stdout
         });
-        const redirectAutomaticallyHint = tempUrl ? '(if not redirected automatically)' : '';
+        const redirectAutomaticallyHint = tempUrl ? ' (if not redirected automatically)' : '';
         const getAccountFromConsole = async () => {
             return await new Promise((resolve) => {
                 rl.question(


### PR DESCRIPTION
This needs a deeper dive to fix properly.