### PR TITLE
address windows, mac, linux behavior w/ callback and auto-open Wallet

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,8 @@ exports.login = async function (options) {
 
         // find a callback URL on the local machine
         try {
-            if (isMac) { // capture callback is currently not working on windows. This is a workaround to not use it
+            // capture callback isn't working reliably outside of Mac. This is a workaround to not use it
+            if (isMac) {
                 tempUrl = await capture.callback(5000);
                 // if we found a suitable URL, attempt to use it
                 newUrl.searchParams.set('success_url', `http://${tempUrl.hostname}:${tempUrl.port}`);

--- a/index.js
+++ b/index.js
@@ -86,23 +86,11 @@ exports.login = async function (options) {
 
         // find a callback URL on the local machine
         try {
-            if (isMac || isLinux) { // capture callback is currently not working on windows. This is a workaround to not use it
+            if (isMac) { // capture callback is currently not working on windows. This is a workaround to not use it
                 tempUrl = await capture.callback(5000);
                 // if we found a suitable URL, attempt to use it
-                if (isMac) {
-                    newUrl.searchParams.set('success_url', `http://${tempUrl.hostname}:${tempUrl.port}`);
-                    await openUrl(newUrl);
-                } else {
-                    // is linux
-                    if (process.env.GITPOD_WORKSPACE_URL) {
-                        const workspaceUrl = new URL(process.env.GITPOD_WORKSPACE_URL);
-                        newUrl.searchParams.set('success_url', `https://${tempUrl.port}-${workspaceUrl.hostname}`);
-                        // Browser not opened, as will open automatically for opened port
-                    } else {
-                        // is linux but not Gitpod
-                        newUrl.searchParams.set('success_url', `http://${tempUrl.hostname}:${tempUrl.port}`);
-                    }
-                }
+                newUrl.searchParams.set('success_url', `http://${tempUrl.hostname}:${tempUrl.port}`);
+                await openUrl(newUrl);
             } else {
                 // redirect automatically, but do not use the browser callback
                 await openUrl(newUrl);
@@ -144,10 +132,8 @@ exports.login = async function (options) {
             accountId = await new Promise((resolve, reject) => {
                 let resolved = false;
                 const resolveOnce = (result) => { if (!resolved) resolve(result); resolved = true; };
-                if (!isLinux) {
-                    getAccountFromWebpage()
-                        .then(resolveOnce); // NOTE: error ignored on purpose
-                }
+                getAccountFromWebpage()
+                    .then(resolveOnce); // NOTE: error ignored on purpose
                 getAccountFromConsole()
                     .then(resolveOnce)
                     .catch(reject);

--- a/index.js
+++ b/index.js
@@ -78,11 +78,7 @@ exports.login = async function (options) {
         // attempt to capture accountId automatically via browser callback
         let tempUrl;
         // See: https://github.com/near/near-shell/issues/358
-        // Mac:     set up a callback       open site automatically
-        // Windows: don't set up callback   open site automatically
-        // Linux:   set up callback         don't open site automatically
         const isMac = process.platform === 'darwin';
-        const isLinux = process.platform === 'linux';
 
         // find a callback URL on the local machine
         try {

--- a/index.js
+++ b/index.js
@@ -77,32 +77,40 @@ exports.login = async function (options) {
 
         // attempt to capture accountId automatically via browser callback
         let tempUrl;
-        const isWin = process.platform === 'win32';
+        // See: https://github.com/near/near-shell/issues/358
+        // Mac:     set up a callback       open site automatically
+        // Windows: don't set up callback   open site automatically
+        // Linux:   set up callback         don't open site automatically
+        const isMac = process.platform === 'darwin';
+        const isLinux = process.platform === 'linux';
 
         // find a callback URL on the local machine
         try {
-            if (!isWin) { // capture callback is currently not working on windows. This is a workaround to not use it
+            if (isMac || isLinux) { // capture callback is currently not working on windows. This is a workaround to not use it
                 tempUrl = await capture.callback(5000);
+                // if we found a suitable URL, attempt to use it
+                if (isMac) {
+                    newUrl.searchParams.set('success_url', `http://${tempUrl.hostname}:${tempUrl.port}`);
+                    await openUrl(newUrl);
+                } else {
+                    // is linux
+                    if (process.env.GITPOD_WORKSPACE_URL) {
+                        const workspaceUrl = new URL(process.env.GITPOD_WORKSPACE_URL);
+                        newUrl.searchParams.set('success_url', `https://${tempUrl.port}-${workspaceUrl.hostname}`);
+                        // Browser not opened, as will open automatically for opened port
+                    } else {
+                        // is linux but not Gitpod
+                        newUrl.searchParams.set('success_url', `http://${tempUrl.hostname}:${tempUrl.port}`);
+                    }
+                }
+            } else {
+                // redirect automatically, but do not use the browser callback
+                await openUrl(newUrl);
             }
         } catch (error) {
             // console.error("Failed to find suitable port.", error.message)
             // TODO: Is it? Try triggering error
             // silent error is better here
-        }
-
-        // if we found a suitable URL, attempt to use it
-        if (tempUrl) {
-            if (process.env.GITPOD_WORKSPACE_URL) {
-                const workspaceUrl = new URL(process.env.GITPOD_WORKSPACE_URL);
-                newUrl.searchParams.set('success_url', `https://${tempUrl.port}-${workspaceUrl.hostname}`);
-                // Browser not opened, as will open automatically for opened port
-            } else {
-                newUrl.searchParams.set('success_url', `http://${tempUrl.hostname}:${tempUrl.port}`);
-                openUrl(newUrl); 
-            }
-        } else if (isWin) {
-            // redirect automatically on windows, but do not use the browser callback
-            openUrl(newUrl);
         }
 
         console.log(chalk`\n{dim If your browser doesn't automatically open, please visit this URL\n${newUrl.toString()}}`);
@@ -136,8 +144,10 @@ exports.login = async function (options) {
             accountId = await new Promise((resolve, reject) => {
                 let resolved = false;
                 const resolveOnce = (result) => { if (!resolved) resolve(result); resolved = true; };
-                getAccountFromWebpage()
-                    .then(resolveOnce); // NOTE: error ignored on purpose
+                if (!isLinux) {
+                    getAccountFromWebpage()
+                        .then(resolveOnce); // NOTE: error ignored on purpose
+                }
                 getAccountFromConsole()
                     .then(resolveOnce)
                     .catch(reject);


### PR DESCRIPTION
Addresses: https://github.com/near/near-shell/issues/358
See the reproduction steps there.
Basically we cannot trust any OS other than Mac to have the callback and auto-open links working consistently.
It was a nice cherry-on-top, but we are causing errant behavior for our users and need to stop it. Unless you're using a Mac.