### PR TITLE
dev-deploy: create neardev directory if it doesn't exist

### DIFF
--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -64,7 +64,10 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
         } catch (e) {
             if (e.code === 'ENOENT') {
                 // Create neardev directory, new account will be created below
-                await mkdir('./neardev');
+                try {
+                    await mkdir('./neardev')
+                } catch (_) {} // if already exists, okay
+
             } else {
                 throw e;
             }

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -54,6 +54,7 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
     // https://github.com/nearprotocol/near-shell/issues/287
     const accountFilePath = 'neardev/dev-account';
     const accountFilePathEnv = 'neardev/dev-account.env';
+    const projectCredentialsPath = './neardev';
     if (!init) {
         try {
             // throws if either file is missing
@@ -65,7 +66,7 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
         } catch (e) {
             if (e.code === 'ENOENT') {
                 // Create neardev directory, new account will be created below
-                if (!existsSync('./neardev')) await mkdir('./neardev');
+                if (!existsSync(projectCredentialsPath)) await mkdir(projectCredentialsPath);
             } else {
                 throw e;
             }

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -1,7 +1,7 @@
 const { KeyPair } = require('near-api-js');
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
-const { readFile, writeFile } = require('fs').promises;
+const { readFile, writeFile, mkdir } = require('fs').promises;
 const eventtracking = require('../utils/eventtracking');
 
 module.exports = {
@@ -63,7 +63,8 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
             }
         } catch (e) {
             if (e.code === 'ENOENT') {
-                // Ignore as it means new account needs to be created, which happens below
+                // Create neardev directory, new account will be created below
+                await mkdir('./neardev');
             } else {
                 throw e;
             }

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -2,6 +2,7 @@ const { KeyPair } = require('near-api-js');
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const { readFile, writeFile, mkdir } = require('fs').promises;
+const { existsSync } = require('fs');
 const eventtracking = require('../utils/eventtracking');
 
 module.exports = {
@@ -64,10 +65,7 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
         } catch (e) {
             if (e.code === 'ENOENT') {
                 // Create neardev directory, new account will be created below
-                try {
-                    await mkdir('./neardev')
-                } catch (_) {} // if already exists, okay
-
+                if (!existsSync('./neardev')) await mkdir('./neardev');
             } else {
                 throw e;
             }

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -4,6 +4,7 @@ const connect = require('../utils/connect');
 const { readFile, writeFile, mkdir } = require('fs').promises;
 const { existsSync } = require('fs');
 const eventtracking = require('../utils/eventtracking');
+const { PROJECT_KEY_DIR } = require('../middleware/key-store');
 
 module.exports = {
     command: 'dev-deploy [wasmFile]',
@@ -52,9 +53,8 @@ async function devDeploy(options) {
 async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
     // TODO: once examples and create-near-app use the dev-account.env file, we can remove the creation of dev-account
     // https://github.com/nearprotocol/near-shell/issues/287
-    const accountFilePath = 'neardev/dev-account';
-    const accountFilePathEnv = 'neardev/dev-account.env';
-    const projectCredentialsPath = './neardev';
+    const accountFilePath = `${PROJECT_KEY_DIR}/dev-account`;
+    const accountFilePathEnv = `${PROJECT_KEY_DIR}/dev-account.env`;
     if (!init) {
         try {
             // throws if either file is missing
@@ -66,7 +66,9 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
         } catch (e) {
             if (e.code === 'ENOENT') {
                 // Create neardev directory, new account will be created below
-                if (!existsSync(projectCredentialsPath)) await mkdir(projectCredentialsPath);
+                if (!existsSync(PROJECT_KEY_DIR)) {
+                    await mkdir(PROJECT_KEY_DIR);
+                }
             } else {
                 throw e;
             }

--- a/middleware/key-store.js
+++ b/middleware/key-store.js
@@ -5,6 +5,7 @@ const MergeKeyStore = nearlib.keyStores.MergeKeyStore;
 const UnencryptedFileSystemKeyStore = nearlib.keyStores.UnencryptedFileSystemKeyStore;
 
 const CREDENTIALS_DIR = '.near-credentials';
+const PROJECT_KEY_DIR = './neardev';
 
 module.exports = async function createKeyStore() {
     // ./neardev is an old way of storing keys under project folder. We want to fallback there for backwards compatibility
@@ -13,7 +14,9 @@ module.exports = async function createKeyStore() {
     const credentialsPath = path.join(homedir, CREDENTIALS_DIR);
     const keyStores = [
         new UnencryptedFileSystemKeyStore(credentialsPath),
-        new UnencryptedFileSystemKeyStore('./neardev')
+        new UnencryptedFileSystemKeyStore(PROJECT_KEY_DIR)
     ];
     return { keyStore: new MergeKeyStore(keyStores) };
 };
+
+module.exports.PROJECT_KEY_DIR = PROJECT_KEY_DIR;

--- a/test_environment.js
+++ b/test_environment.js
@@ -2,6 +2,8 @@ const NodeEnvironment = require('jest-environment-node');
 const nearlib = require('near-api-js');
 const fs = require('fs');
 
+const { PROJECT_KEY_DIR } = require('./middleware/key-store');
+
 const INITIAL_BALANCE = '500000000000000000000000000';
 const testAccountName = 'test.near';
 
@@ -19,7 +21,7 @@ class LocalTestEnvironment extends NodeEnvironment {
             contractName: 'test' + Date.now(),
             accountId: 'test' + Date.now()
         });
-        const keyStore = new nearlib.keyStores.UnencryptedFileSystemKeyStore('./neardev');
+        const keyStore = new nearlib.keyStores.UnencryptedFileSystemKeyStore(PROJECT_KEY_DIR);
         config.deps = Object.assign(config.deps || {}, {
             storage:  this.createFakeStorage(),
             keyStore,


### PR DESCRIPTION
If there's no `neardev` directory, `near dev-deploy` will fail with:

```
Error:  [Error: ENOENT: no such file or directory, open 'neardev/dev-account'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'neardev/dev-account'
}
error Command failed with exit code 1.
```

This is new behavior as of 0.23.0, let's address this quickly.

Tested by going into guest-book example locally:
`../near-shell/bin/near dev-deploy`

`rm -rf neardev`
then running it again
`rm neardev/dev-account*`
then running it again