### PR TITLE
refactor: replace `nearlib` with `nearAPI`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/near/near-shell.svg?branch=master)](https://travis-ci.com/near/near-shell)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/near/near-shell) 
 
-NEAR Shell is a Node.js application that relies on [`nearlib`](https://github.com/nearprotocol/nearlib) to generate secure keys, connect to the NEAR platform and send transactions to the network on your behalf.
+NEAR Shell is a Node.js application that relies on [`near-api-js`](https://github.com/near/near-api-js) to generate secure keys, connect to the NEAR platform and send transactions to the network on your behalf.
 
 > note that **Node.js version 10+** is required to run NEAR Shell
 

--- a/commands/call.js
+++ b/commands/call.js
@@ -1,5 +1,4 @@
-const nearlib = require('near-api-js');
-const { utils } = nearlib;
+const { providers, utils } = require('near-api-js');
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const inspectResponse = require('../utils/inspect-response');
@@ -34,7 +33,7 @@ async function scheduleFunctionCall(options) {
         JSON.parse(options.args || '{}'),
         options.gas,
         utils.format.parseNearAmount(options.amount));
-    const result = nearlib.providers.getTransactionLastResult(functionCallResponse);
+    const result = providers.getTransactionLastResult(functionCallResponse);
     console.log(inspectResponse(result));
     await eventtracking.track(eventtracking.EVENT_ID_SCHEDULE_FN_CALL_END, { node: options.nodeUrl, success: true });
 }

--- a/commands/repl.js
+++ b/commands/repl.js
@@ -5,7 +5,7 @@ module.exports = {
     handler: async (argv) => {
         const repl = require('repl');
         const context = repl.start('> ').context;
-        context.nearlib = require('near-api-js');
+        context.nearAPI = require('near-api-js');
         context.near = await require('../utils/connect')(argv);
         if (argv.accountId) {
             context.account = await context.near.account(argv.accountId);

--- a/middleware/key-store.js
+++ b/middleware/key-store.js
@@ -1,8 +1,8 @@
-const nearlib = require('near-api-js');
+const { keyStores } = require('near-api-js');
 const homedir = require('os').homedir();
 const path = require('path');
-const MergeKeyStore = nearlib.keyStores.MergeKeyStore;
-const UnencryptedFileSystemKeyStore = nearlib.keyStores.UnencryptedFileSystemKeyStore;
+const MergeKeyStore = keyStores.MergeKeyStore;
+const UnencryptedFileSystemKeyStore = keyStores.UnencryptedFileSystemKeyStore;
 
 const CREDENTIALS_DIR = '.near-credentials';
 

--- a/test_environment.js
+++ b/test_environment.js
@@ -1,5 +1,5 @@
 const NodeEnvironment = require('jest-environment-node');
-const nearlib = require('near-api-js');
+const nearAPI = require('near-api-js');
 const fs = require('fs');
 
 const INITIAL_BALANCE = '500000000000000000000000000';
@@ -12,6 +12,7 @@ class LocalTestEnvironment extends NodeEnvironment {
 
     async setup() {
         this.global.nearlib = require('near-api-js');
+        this.global.nearAPI = require('near-api-js');
         this.global.window = {};
         let config = require('./get-config')();
         this.global.testSettings = this.global.nearConfig = config;
@@ -19,15 +20,15 @@ class LocalTestEnvironment extends NodeEnvironment {
             contractName: 'test' + Date.now(),
             accountId: 'test' + Date.now()
         });
-        const keyStore = new nearlib.keyStores.UnencryptedFileSystemKeyStore('./neardev');
+        const keyStore = new nearAPI.keyStores.UnencryptedFileSystemKeyStore('./neardev');
         config.deps = Object.assign(config.deps || {}, {
             storage:  this.createFakeStorage(),
             keyStore,
         });
-        const near = await nearlib.connect(config);
+        const near = await nearAPI.connect(config);
 
         const masterAccount = await near.account(testAccountName);
-        const randomKey = await nearlib.KeyPair.fromRandom('ed25519');
+        const randomKey = await nearAPI.KeyPair.fromRandom('ed25519');
         const data = [...fs.readFileSync('./out/main.wasm')];
         await config.deps.keyStore.setKey(config.networkId, config.contractName, randomKey);
         await masterAccount.createAndDeployContract(config.contractName, randomKey.getPublicKey(), data, INITIAL_BALANCE);

--- a/utils/connect.js
+++ b/utils/connect.js
@@ -1,6 +1,6 @@
-const nearlib = require('near-api-js');
+const { connect: nearConnect } = require('near-api-js');
 
 module.exports = async function connect({ keyStore, ...options }) {
     // TODO: Avoid need to wrap in deps
-    return await nearlib.connect({ ...options, deps: { keyStore }});
+    return await nearConnect({ ...options, deps: { keyStore }});
 };


### PR DESCRIPTION
Fixes #312 

We already switched dependencies from the `nearlib` library to `near-api-js`. This mostly completes the process by renaming the imported constant.

Given that `test_environment.js` is a dependency in use by many apps, I have opted to leave its initialization of a `nearlib` global in-place for now. Once we complete near-examples/counter#44, we will have a better idea of how to recommend people migrate away from `test_environment` altogether, at which point we can deprecate the whole file and link people to an upgrade guide. However, I have also opted to add a `nearAPI` global here. We can keep this unadvertised, but it seems strange now to set up a `nearlib` global but none for `nearAPI`

`near repl` is barely used by the current NEAR community, so I've updated the exported global name directly, without keeping the `nearlib` name around behind a deprecation warning.
