### PR TITLE
Ask for event tracking opt-in only in interactive commands

### DIFF
--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -32,6 +32,7 @@ module.exports = {
 };
 
 async function devDeploy(options) {
+    await eventtracking.askForConsentIfNeeded();
     await eventtracking.track(eventtracking.EVENT_ID_DEV_DEPLOY_START, { node: options.nodeUrl });
     const { nodeUrl, helperUrl, masterAccount, wasmFile } = options;
 

--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ const openUrl = async function(url) {
 };
 
 exports.login = async function (options) {
+    await eventtracking.askForConsentIfNeeded();
     await eventtracking.track(eventtracking.EVENT_ID_LOGIN_START, { node: options.nodeUrl });
     if (!options.walletUrl) {
         console.log('Log in is not needed on this environment. Please use appropriate master account for shell operations.');


### PR DESCRIPTION
For now this includes:
 - near login
 - near dev-deploy

Related to https://github.com/near/near-shell/issues/306

This change had to be done to make sure that opt-in flow doesn't interfere with usage in scripts.