### PR TITLE
add delete-key command to delete access key

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -91,18 +91,6 @@ const stake = {
     handler: exitOnError(main.stake)
 };
 
-const deleteAccessKey = {
-    command: 'delete-key [accessKey]',
-    desc: 'delete access key',
-    builder: (yargs) => yargs
-        .option('accessKey', {
-            desc: 'Public key to delete (base58 encoded)',
-            type: 'string',
-            required: true,
-        }),
-    handler: exitOnError(main.deleteAccessKey)
-};
-
 // For contract:
 const deploy = {
     command: 'deploy',
@@ -203,10 +191,10 @@ yargs // eslint-disable-line
     .command(sendMoney)
     .command(clean)
     .command(stake)
-    .command(deleteAccessKey)
     .command(login)
     .command(require('../commands/repl'))
     .command(require('../commands/generate-key'))
+    .command(require('../commands/delete-key'))
     .command(require('../commands/validators'))
     .command(require('../commands/proposals'))
     .config(config)

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -92,7 +92,7 @@ const stake = {
 };
 
 const deleteAccessKey = {
-    command: 'delete-key [publicKey]',
+    command: 'delete-key [accessKey]',
     desc: 'delete access key',
     builder: (yargs) => yargs
         .option('accessKey', {

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -91,6 +91,18 @@ const stake = {
     handler: exitOnError(main.stake)
 };
 
+const deleteAccessKey = {
+    command: 'delete-key [publicKey]',
+    desc: 'delete access key',
+    builder: (yargs) => yargs
+        .option('accessKey', {
+            desc: 'Public key to delete (base58 encoded)',
+            type: 'string',
+            required: true,
+        }),
+    handler: exitOnError(main.deleteAccessKey)
+};
+
 // For contract:
 const deploy = {
     command: 'deploy',
@@ -113,7 +125,6 @@ const callViewFunction = {
     builder: (yargs) => yargs,
     handler: exitOnError(main.callViewFunction)
 };
-
 
 const build = {
     command: 'build',
@@ -192,6 +203,7 @@ yargs // eslint-disable-line
     .command(sendMoney)
     .command(clean)
     .command(stake)
+    .command(deleteAccessKey)
     .command(login)
     .command(require('../commands/repl'))
     .command(require('../commands/generate-key'))

--- a/commands/delete-key.js
+++ b/commands/delete-key.js
@@ -1,0 +1,26 @@
+const exitOnError = require('../utils/exit-on-error');
+const connect = require('../utils/connect');
+const eventtracking = require('../utils/eventtracking');
+const inspectResponse = require('../utils/inspect-response');
+
+module.exports = {
+    command: 'delete-key [accessKey]',
+    desc: 'delete access key',
+    builder: (yargs) => yargs
+        .option('accessKey', {
+            desc: 'Public key to delete (base58 encoded)',
+            type: 'string',
+            required: true,
+        }),
+    handler: exitOnError(deleteAccessKey)
+};
+
+async function deleteAccessKey(options) {
+    await eventtracking.track(eventtracking.EVENT_ID_DELETE_KEY_START, { node: options.nodeUrl, amount: options.amount });
+    console.log(`Deleting key = ${options.accessKey} on ${options.accountId}.`);
+    const near = await connect(options);
+    const account = await near.account(options.accountId);
+    const result = await account.deleteKey(options.accessKey);
+    console.log(inspectResponse(result));
+    await eventtracking.track(eventtracking.EVENT_ID_DELETE_KEY_END, { node: options.nodeUrl, success: true });
+}

--- a/index.js
+++ b/index.js
@@ -199,6 +199,16 @@ exports.sendMoney = async function (options) {
     await eventtracking.track(eventtracking.EVENT_ID_SEND_TOKENS_END, { node: options.nodeUrl, success: true });
 };
 
+exports.deleteAccessKey = async function (options) {
+    await eventtracking.track(eventtracking.EVENT_ID_DELETE_KEY_START, { node: options.nodeUrl, amount: options.amount });
+    console.log(`Deleting key = ${options.accessKey} on ${options.accountId}.`);
+    const near = await connect(options);
+    const account = await near.account(options.accountId);
+    const result = await account.deleteKey(options.accessKey);
+    console.log(inspectResponse(result));
+    await eventtracking.track(eventtracking.EVENT_ID_DELETE_KEY_END, { node: options.nodeUrl, success: true });
+};
+
 exports.stake = async function (options) {
     await eventtracking.track(eventtracking.EVENT_ID_STAKE_START, { node: options.nodeUrl, amount: options.amount });
     console.log(`Staking ${options.amount} (${utils.format.parseNearAmount(options.amount)}) on ${options.accountId} with public key = ${options.stakingKey}.`);

--- a/index.js
+++ b/index.js
@@ -199,16 +199,6 @@ exports.sendMoney = async function (options) {
     await eventtracking.track(eventtracking.EVENT_ID_SEND_TOKENS_END, { node: options.nodeUrl, success: true });
 };
 
-exports.deleteAccessKey = async function (options) {
-    await eventtracking.track(eventtracking.EVENT_ID_DELETE_KEY_START, { node: options.nodeUrl, amount: options.amount });
-    console.log(`Deleting key = ${options.accessKey} on ${options.accountId}.`);
-    const near = await connect(options);
-    const account = await near.account(options.accountId);
-    const result = await account.deleteKey(options.accessKey);
-    console.log(inspectResponse(result));
-    await eventtracking.track(eventtracking.EVENT_ID_DELETE_KEY_END, { node: options.nodeUrl, success: true });
-};
-
 exports.stake = async function (options) {
     await eventtracking.track(eventtracking.EVENT_ID_STAKE_START, { node: options.nodeUrl, amount: options.amount });
     console.log(`Staking ${options.amount} (${utils.format.parseNearAmount(options.amount)}) on ${options.accountId} with public key = ${options.stakingKey}.`);

--- a/utils/eventtracking.js
+++ b/utils/eventtracking.js
@@ -109,5 +109,7 @@ module.exports = {
     EVENT_ID_REPL_END: 'shell_repl_end',
     EVENT_ID_GENERATE_KEY_START: 'shell_generate_key_start',
     EVENT_ID_GENERATE_KEY_END: 'shell_id_generate_key_end',
+    EVENT_ID_DELETE_KEY_START: 'event_id_delete_key_start',
+    EVENT_ID_DELETE_KEY_END: 'event_id_delete_key_end',
     EVENT_ID_ERROR: 'shell_error' // This is not used right now because of mixpanel bug.
 };


### PR DESCRIPTION
Delete's an access key.
Pull down branch and you can use this command
Command:
`./bin/near delete-key 2rLDDvyk8wdpq4TZ3k2xmCxhykq431eNKQ7Mfg31nT4q --accountId mike.testnet`

The access key can be copied from Wallet. Tested on full access and authorized apps keys.