### PR TITLE
Fix https://github.com/near/near-shell/issues/393

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -140,12 +140,12 @@ yargs // eslint-disable-line
     .option('nodeUrl', {
         desc: 'NEAR node URL',
         type: 'string',
-        default: 'https://rpc.testnet.near.org'
+        default: config.nodeUrl
     })
     .option('networkId', {
         desc: 'NEAR network ID, allows using different keys based on network',
         type: 'string',
-        default: 'default'
+        default: config.networkId
     })
     .option('helperUrl', {
         desc: 'NEAR contract helper URL',

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -140,7 +140,7 @@ yargs // eslint-disable-line
     .option('nodeUrl', {
         desc: 'NEAR node URL',
         type: 'string',
-        default: 'http://localhost:3030'
+        default: 'https://rpc.testnet.near.org'
     })
     .option('networkId', {
         desc: 'NEAR network ID, allows using different keys based on network',


### PR DESCRIPTION
Fixed help to match what is actually happening.

node bin\near login --help
near login

logging in through NEAR protocol wallet

Options:
  --help                     Show help  [boolean]
  --version                  Show version number  [boolean]
  --nodeUrl, --node_url      NEAR node URL  [string] [default: "https://rpc.testnet.near.org"]
  --networkId, --network_id  NEAR network ID, allows using different keys based on network  [string] [default: "default"]
  --helperUrl                NEAR contract helper URL  [string]
  --keyPath                  Path to master account key  [string]
  --accountId, --account_id  Unique identifier for the account  [string]
  --useLedgerKey             Use Ledger for signing with given HD key path  [string] [default: "44'/397'/0'/0'/1'"]