### PR TITLE
Fix for https://github.com/near/near-shell/issues/385

### DIFF
--- a/utils/validators-info.js
+++ b/utils/validators-info.js
@@ -16,7 +16,7 @@ async function showValidatorsTable(near, epochId) {
     result.current_validators = result.current_validators.sort((a, b) => -new BN(a.stake).cmp(new BN(b.stake)));
     var validatorsTable = new AsciiTable();
     validatorsTable.setHeading('Validator Id', 'Stake', '# Seats', '% Online', 'Blocks produced', 'Blocks expected');
-    console.log(`Validators (total: ${result.current_validators.length}, seat price: ${utils.format.formatNearAmount(seatPrice, 0)}):`);
+    console.log(`Validators (total: ${result.current_validators.length}, seat price: ${utils.format.formatNearAmount(seatPrice.toString(), 0)}):`);
     result.current_validators.forEach((validator) => {
         validatorsTable.addRow(
             validator.account_id,

--- a/utils/validators-info.js
+++ b/utils/validators-info.js
@@ -34,7 +34,7 @@ async function showNextValidatorsTable(near) {
     const nextSeatPrice = validators.findSeatPrice(result.next_validators, result.numSeats);
     result.next_validators = result.next_validators.sort((a, b) => -new BN(a.stake).cmp(new BN(b.stake)));
     const diff = validators.diffEpochValidators(result.current_validators, result.next_validators);
-    console.log(`\nNext validators (total: ${result.next_validators.length}, seat price: ${utils.format.formatNearAmount(nextSeatPrice, 0)}):`);
+    console.log(`\nNext validators (total: ${result.next_validators.length}, seat price: ${utils.format.formatNearAmount(nextSeatPrice.toString(), 0)}):`);
     let nextValidatorsTable = new AsciiTable();
     nextValidatorsTable.setHeading('Status', 'Validator', 'Stake', '# Seats');
     diff.newValidators.forEach((validator) => nextValidatorsTable.addRow(
@@ -66,7 +66,7 @@ async function showProposalsTable(near) {
     const combinedProposals = combineValidatorsAndProposals(result.current_validators, proposals);
     const expectedSeatPrice = validators.findSeatPrice(combinedProposals, result.numSeats);
     const combinedPassingProposals = combinedProposals.filter((p) => new BN(p.stake).gte(expectedSeatPrice));
-    console.log(`Proposals for the epoch after next (new: ${proposals.size}, passing: ${combinedPassingProposals.length}, expected seat price = ${utils.format.formatNearAmount(expectedSeatPrice, 0)})`);
+    console.log(`Proposals for the epoch after next (new: ${proposals.size}, passing: ${combinedPassingProposals.length}, expected seat price = ${utils.format.formatNearAmount(expectedSeatPrice.toString(), 0)})`);
     const proposalsTable = new AsciiTable();
     proposalsTable.setHeading('Status', 'Validator', 'Stake => New Stake', '# Seats');
     combinedProposals.sort((a, b) => -new BN(a.stake).cmp(new BN(b.stake))).forEach((proposal) => {


### PR DESCRIPTION
Should be passing a string here...

```
/**
 * Convert account balance value from internal indivisible units to NEAR. 1 NEAR is defined by {@link NEAR_NOMINATION}.
 * Effectively this divides given amount by {@link NEAR_NOMINATION}.
 *
 * @param balance decimal string representing balance in smallest non-divisible NEAR units (as specified by {@link NEAR_NOMINATION})
 * @param fracDigits number of fractional digits to preserve in formatted string. Balance is rounded to match given number of digits.
 * @returns Value in Ⓝ
 */
function formatNearAmount(balance, fracDigits = exports.NEAR_NOMINATION_EXP) {
```