### PR TITLE
Add more Info to help docs for repl

### DIFF
--- a/commands/repl.js
+++ b/commands/repl.js
@@ -1,7 +1,7 @@
 module.exports = {
     command: 'repl',
     desc: 'launch interactive Node.js shell with NEAR connection available to use. The repl\'s initial context contains `nearAPI`, `near`and `account` if an accountId cli argument is provided. ' +
-           'To load a script into the reple use  ".load script.js".\n\n' + 
+           'To load a script into the repl use  ".load script.js".\n\n' + 
            'USAGE:\n' +
            '    near repl --acountId bob\n    > console.log(account)\n    > .load script.js',
     builder: (yargs) => yargs,

--- a/commands/repl.js
+++ b/commands/repl.js
@@ -1,6 +1,9 @@
 module.exports = {
     command: 'repl',
-    desc: 'launch interactive Node.js shell with NEAR connection available to use',
+    desc: 'launch interactive Node.js shell with NEAR connection available to use. The repl\'s initial context contains `nearAPI`, `near`and `account` if an accountId cli argument is provided. ' +
+           'To load a script into the reple use  ".load script.js".\n\n' + 
+           'USAGE:\n' +
+           '    near repl --acountId bob\n    > console.log(account)\n    > .load script.js',
     builder: (yargs) => yargs,
     handler: async (argv) => {
         const repl = require('repl');


### PR DESCRIPTION
- Add that the `.load` command can be used to load scripts into the repl
- List the provided variables in the repl context.
- Provide usage example