### PR TITLE
Add basic crash reporting to near-cli

### DIFF
--- a/utils/crash-error-report.js
+++ b/utils/crash-error-report.js
@@ -5,5 +5,4 @@ const mixPanelProperties = {
     error_message: process.env.NEAR_CLI_LAST_ERROR,
     network_id: process.env.NEAR_CLI_NETWORK_ID
 };
-Object.assign(mixPanelProperties, {});
 eventtracking.track(eventtracking.EVENT_ID_ERROR, mixPanelProperties);

--- a/utils/crash-error-report.js
+++ b/utils/crash-error-report.js
@@ -3,7 +3,7 @@ const eventtracking = require('./eventtracking');
 const mixPanelProperties = {
   near_shell_command: process.env.NEAR_CLI_ERROR_LAST_COMMAND,
   error_message: process.env.NEAR_CLI_LAST_ERROR,
-  environment: process.env.NODE_ENV 
+  network_id: process.env.NEAR_CLI_NETWORK_ID
 };
 Object.assign(mixPanelProperties, {});
 eventtracking.track(eventtracking.EVENT_ID_ERROR, mixPanelProperties);

--- a/utils/crash-error-report.js
+++ b/utils/crash-error-report.js
@@ -1,9 +1,9 @@
 const eventtracking = require('./eventtracking');
 
 const mixPanelProperties = {
-  near_shell_command: process.env.NEAR_CLI_ERROR_LAST_COMMAND,
-  error_message: process.env.NEAR_CLI_LAST_ERROR,
-  network_id: process.env.NEAR_CLI_NETWORK_ID
+    near_shell_command: process.env.NEAR_CLI_ERROR_LAST_COMMAND,
+    error_message: process.env.NEAR_CLI_LAST_ERROR,
+    network_id: process.env.NEAR_CLI_NETWORK_ID
 };
 Object.assign(mixPanelProperties, {});
 eventtracking.track(eventtracking.EVENT_ID_ERROR, mixPanelProperties);

--- a/utils/crash-error-report.js
+++ b/utils/crash-error-report.js
@@ -1,0 +1,9 @@
+const eventtracking = require('./eventtracking');
+
+const mixPanelProperties = {
+  near_shell_command: process.env.NEAR_CLI_ERROR_LAST_COMMAND,
+  error_message: process.env.NEAR_CLI_LAST_ERROR,
+  environment: process.env.NODE_ENV 
+};
+Object.assign(mixPanelProperties, {});
+eventtracking.track(eventtracking.EVENT_ID_ERROR, mixPanelProperties);

--- a/utils/eventtracking.js
+++ b/utils/eventtracking.js
@@ -111,5 +111,5 @@ module.exports = {
     EVENT_ID_GENERATE_KEY_END: 'shell_id_generate_key_end',
     EVENT_ID_DELETE_KEY_START: 'event_id_delete_key_start',
     EVENT_ID_DELETE_KEY_END: 'event_id_delete_key_end',
-    EVENT_ID_ERROR: 'shell_error' // This is not used right now because of mixpanel bug.
+    EVENT_ID_ERROR: 'event_id_shell_error'
 };

--- a/utils/exit-on-error.js
+++ b/utils/exit-on-error.js
@@ -1,8 +1,23 @@
+// This is a workaround to get Mixpanel to log a crash
+process.on('exit', () => {
+    require('child_process').fork(__dirname + '/crash-error-report.js', ['node'], {
+        silent: true,
+        detached: true,
+        // TODO: pass info on environment
+        env: {
+            NEAR_CLI_ERROR_LAST_COMMAND: process.env.NEAR_CLI_ERROR_LAST_COMMAND,
+            NEAR_CLI_LAST_ERROR: process.env.NEAR_CLI_LAST_ERROR
+        }
+    });
+});
+
 module.exports = (promiseFn) => async (...args) => {
+    process.env.NEAR_CLI_ERROR_LAST_COMMAND = args[0]['_'];
     const promise = promiseFn.apply(null, args);
     try {
         await promise;
     } catch (e) {
+        process.env.NEAR_CLI_LAST_ERROR = e.message;
         console.log('Error: ', e);
         process.exit(1);
     }

--- a/utils/exit-on-error.js
+++ b/utils/exit-on-error.js
@@ -3,7 +3,6 @@ process.on('exit', () => {
     require('child_process').fork(__dirname + '/crash-error-report.js', ['node'], {
         silent: true,
         detached: true,
-        // TODO: pass info on environment
         env: {
             NEAR_CLI_ERROR_LAST_COMMAND: process.env.NEAR_CLI_ERROR_LAST_COMMAND,
             NEAR_CLI_LAST_ERROR: process.env.NEAR_CLI_LAST_ERROR,

--- a/utils/exit-on-error.js
+++ b/utils/exit-on-error.js
@@ -6,13 +6,15 @@ process.on('exit', () => {
         // TODO: pass info on environment
         env: {
             NEAR_CLI_ERROR_LAST_COMMAND: process.env.NEAR_CLI_ERROR_LAST_COMMAND,
-            NEAR_CLI_LAST_ERROR: process.env.NEAR_CLI_LAST_ERROR
+            NEAR_CLI_LAST_ERROR: process.env.NEAR_CLI_LAST_ERROR,
+            NEAR_CLI_NETWORK_ID: process.env.NEAR_CLI_NETWORK_ID
         }
     });
 });
 
 module.exports = (promiseFn) => async (...args) => {
     process.env.NEAR_CLI_ERROR_LAST_COMMAND = args[0]['_'];
+    process.env.NEAR_CLI_NETWORK_ID = require('../get-config')()['networkId'];
     const promise = promiseFn.apply(null, args);
     try {
         await promise;


### PR DESCRIPTION
This requires adding a workaround to spawn a child process, since
mixpanel does not handle this case properly.

There is an existing limitation that if a user did not opt in to
tracking, the crash report will not be sent. We may want to ask an
additional qustion for this case, since there are scenarios where people
are willing to send an individual crash report but not opt in to general
tracking.

There is a known limitation that this implementation does not log the
environment that was used.