### PR TITLE
In create_account, create key first to avoid unusable accounts and funds

### DIFF
--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -55,13 +55,13 @@ async function createAccount(options) {
         await near.createAccount(options.accountId, publicKey);
     } catch(error) {
         if (error.message.includes('Timeout')) {
-            console.warn("Received a timeout when creating account, please run:");
+            console.warn('Received a timeout when creating account, please run:');
             console.warn(`near state ${options.accountId}`);
-            console.warn("to confirm creation. Keyfile for this account has been saved.");
+            console.warn('to confirm creation. Keyfile for this account has been saved.');
         } else {
             near.connection.signer.keyStore.removeKey(options.networkId, options.accountId)
                 .then(() => {
-                    throw error
+                    throw error;
                 }).catch((e) => console.error(e));
         }
     }

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -131,19 +131,17 @@ async function createAccount(options) {
     // Create account
     try {
         await near.createAccount(options.accountId, publicKey);
+        console.log(`Account ${options.accountId} for network "${options.networkId}" was created.`);
     } catch(error) {
         if (error.message.includes('Timeout')) {
             console.warn('Received a timeout when creating account, please run:');
             console.warn(`near state ${options.accountId}`);
             console.warn('to confirm creation. Keyfile for this account has been saved.');
         } else {
-            near.connection.signer.keyStore.removeKey(options.networkId, options.accountId)
-                .then(() => {
-                    throw error;
-                }).catch((e) => console.error(e));
+            await near.connection.signer.keyStore.removeKey(options.networkId, options.accountId)
+            throw error;
         }
     }
-    console.log(`Account ${options.accountId} for network "${options.networkId}" was created.`);
 }
 
 module.exports = {

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -81,18 +81,16 @@ async function createAccount(options) {
     if (splitAccount.length === 1) {
         // TLA (bob-with-at-least-maximum-characters)
         if (splitAccount[0].length < TLA_MIN_LENGTH) {
-            console.log(`Top-level accounts must be at least ${TLA_MIN_LENGTH} characters.\n` +
+            throw new Error(`Top-level accounts must be at least ${TLA_MIN_LENGTH} characters.\n` +
               'Note: this is for advanced usage only. Typical account names are of the form:\n' +
               'app.alice.test, where the masterAccount shares the top-level account (.test).'
             );
-            return;
         }
     } else if (splitAccount.length > 1) {
         // Subaccounts (short.alice.near, even.more.bob.test, and eventually peter.potato)
         // Check that master account TLA matches
         if (!options.accountId.endsWith(`.${options.masterAccount}`)) {
-            console.log(`New account doesn't share the same top-level account. Expecting account name to end in ".${options.masterAccount}"`);
-            return;
+            throw new Error(`New account doesn't share the same top-level account. Expecting account name to end in ".${options.masterAccount}"`);
         }
 
         // Warn user if account seems to be using wrong network, where TLA is captured in config
@@ -121,8 +119,7 @@ async function createAccount(options) {
     try {
         // This is expected to error because the account shouldn't exist
         await near.account(options.accountId);
-        console.error(`Sorry, account '${options.accountId}' already exists.`);
-        process.exit(1);
+        throw new Error(`Sorry, account '${options.accountId}' already exists.`);
     } catch (e) {
         if (!e.message.includes('does not exist while viewing')) {
             throw e;

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -117,6 +117,19 @@ async function createAccount(options) {
     } else {
         await eventtracking.track(eventtracking.EVENT_ID_CREATE_ACCOUNT_END, { success: true, new_keypair: false }, options);
     }
+    // Check to see if account already exists
+    try {
+        // This is expected to error because the account shouldn't exist
+        await near.account(options.accountId);
+        console.error(`Sorry, account '${options.accountId}' already exists.`);
+        return;
+    } catch (e) {
+        if (!e.message.includes('does not exist while viewing')) {
+            console.error('Error while checking for existence of account', e);
+            return;
+        }
+    }
+    // Create account
     try {
         await near.createAccount(options.accountId, publicKey);
     } catch(error) {

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -130,7 +130,7 @@ async function createAccount(options) {
         await near.createAccount(options.accountId, publicKey);
         console.log(`Account ${options.accountId} for network "${options.networkId}" was created.`);
     } catch(error) {
-        if (error.message.includes('Timeout')) {
+        if (error.type === 'RetriesExceeded') {
             console.warn('Received a timeout when creating account, please run:');
             console.warn(`near state ${options.accountId}`);
             console.warn('to confirm creation. Keyfile for this account has been saved.');

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -122,11 +122,10 @@ async function createAccount(options) {
         // This is expected to error because the account shouldn't exist
         await near.account(options.accountId);
         console.error(`Sorry, account '${options.accountId}' already exists.`);
-        return;
+        process.exit(1);
     } catch (e) {
         if (!e.message.includes('does not exist while viewing')) {
-            console.error('Error while checking for existence of account', e);
-            return;
+            throw e;
         }
     }
     // Create account


### PR DESCRIPTION
Two things to address here. 
1. DevX usability as we frequently see timeout errors
2. I believe we need this long term, especially for mainnet.

Regarding 2, take this example. A user creates a subaccount on mainnet, sending it a lot of valuable tokens with
`near create_account rich.mike.near --masterAccount mike.near --initialBalance 999999`
Currently the RPC request is called *first* with `await` and if successful, the key file is created.
If lightning strikes this person's house and the internet goes out **immediately after the RPC call** and before the key file is created, this account is bricked and the user has lost 999999 Ⓝ.

What this PR does is create the key file first, then make the async calls. If there's an error it'll delete the key file. Caveat: if that error is a timeout, it'll prompt the user with useful information and *not* delete the key file.

I tried using the error's `type` but sadly that wont work. I have to parse the error message for `Timeout`. The `type = UntypedError`. It's always like this:

```
Error:  TypedError: [-32000] Server error: Timeout error
    at JsonRpcProvider.sendJsonRpc (/Users/mike/.nvm/versions/node/v12.16.0/lib/node_modules/near-shell/node_modules/near-api-js/lib/providers/json-rpc-provider.js:129:27)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async /Users/mike/.nvm/versions/node/v12.16.0/lib/node_modules/near-shell/commands/tx-status.js:35:24
    at async Object.handler (/Users/mike/.nvm/versions/node/v12.16.0/lib/node_modules/near-shell/utils/exit-on-error.js:4:9) {
  type: 'UntypedError'
}
```

Here's a patch file (I had to add the `.txt` extension so that Github would upload it) for `nearcore` to hack it to return a timeout error:
[always-server-timeout.patch.txt](https://github.com/near/near-shell/files/4737192/always-server-timeout.patch.txt)

Note: I wasn't able to use `await` in the `catch` hence the use of `.then` in this PR.

I've included a video of it in action. First we show that the file is being deleted when parsing the error message for an error that's *note* `Timeout` to illustrate that it deletes the key file afterward. Then we fix it to look for `Timeout` and observe that the key file will persist and the message is displayed to the user.

Video link from Discord: https://discordapp.com/channels/490367152054992913/542945453533036544/718492520320991302

