### PR TITLE
Track network id and node url consistently

### DIFF
--- a/commands/call.js
+++ b/commands/call.js
@@ -22,7 +22,7 @@ module.exports = {
 };
 
 async function scheduleFunctionCall(options) {
-    await eventtracking.track(eventtracking.EVENT_ID_SCHEDULE_FN_CALL_START, { node: options.nodeUrl });
+    await eventtracking.track(eventtracking.EVENT_ID_SCHEDULE_FN_CALL_START, {}, options);
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
         (options.amount && options.amount != '0' ? ` with attached ${options.amount} NEAR` : ''));
     const near = await connect(options);
@@ -35,5 +35,5 @@ async function scheduleFunctionCall(options) {
         utils.format.parseNearAmount(options.amount));
     const result = providers.getTransactionLastResult(functionCallResponse);
     console.log(inspectResponse(result));
-    await eventtracking.track(eventtracking.EVENT_ID_SCHEDULE_FN_CALL_END, { node: options.nodeUrl, success: true });
+    await eventtracking.track(eventtracking.EVENT_ID_SCHEDULE_FN_CALL_END, { success: true }, options);
 }

--- a/commands/call.js
+++ b/commands/call.js
@@ -2,7 +2,6 @@ const { providers, utils } = require('near-api-js');
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const inspectResponse = require('../utils/inspect-response');
-const eventtracking = require('../utils/eventtracking');
 
 module.exports = {
     command: 'call <contractName> <methodName> [args]',
@@ -22,7 +21,6 @@ module.exports = {
 };
 
 async function scheduleFunctionCall(options) {
-    await eventtracking.track(eventtracking.EVENT_ID_SCHEDULE_FN_CALL_START, {}, options);
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
         (options.amount && options.amount != '0' ? ` with attached ${options.amount} NEAR` : ''));
     const near = await connect(options);
@@ -35,5 +33,4 @@ async function scheduleFunctionCall(options) {
         utils.format.parseNearAmount(options.amount));
     const result = providers.getTransactionLastResult(functionCallResponse);
     console.log(inspectResponse(result));
-    await eventtracking.track(eventtracking.EVENT_ID_SCHEDULE_FN_CALL_END, { success: true }, options);
 }

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -37,7 +37,7 @@ module.exports = {
 };
 
 async function createAccount(options) {
-    await eventtracking.track(eventtracking.EVENT_ID_CREATE_ACCOUNT_START, { nodeUrl: options.nodeUrl });
+    await eventtracking.track(eventtracking.EVENT_ID_CREATE_ACCOUNT_START, {}, options);
     // NOTE: initialBalance is passed as part of config here, parsed in middleware/initial-balance
     let near = await connect(options);
     let keyPair;
@@ -53,5 +53,5 @@ async function createAccount(options) {
         await near.connection.signer.keyStore.setKey(options.networkId, options.accountId, keyPair);
     }
     console.log(`Account ${options.accountId} for network "${options.networkId}" was created.`);
-    await eventtracking.track(eventtracking.EVENT_ID_CREATE_ACCOUNT_END, { node: options.nodeUrl, success: true });
+    await eventtracking.track(eventtracking.EVENT_ID_CREATE_ACCOUNT_END, { success: true }, options);
 }

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -70,7 +70,6 @@ const createAccountCommandDeprecated = {
 }; 
 
 async function createAccount(options) {
-    await eventtracking.track(eventtracking.EVENT_ID_CREATE_ACCOUNT_START, {}, options);
     // NOTE: initialBalance is passed as part of config here, parsed in middleware/initial-balance
     let near = await connect(options);
     let keyPair;
@@ -84,9 +83,11 @@ async function createAccount(options) {
     await near.createAccount(options.accountId, publicKey);
     if (keyPair) {
         await near.connection.signer.keyStore.setKey(options.networkId, options.accountId, keyPair);
+        await eventtracking.track(eventtracking.EVENT_ID_CREATE_ACCOUNT_END, { success: true, new_keypair: true }, options);
+    } else {
+        await eventtracking.track(eventtracking.EVENT_ID_CREATE_ACCOUNT_END, { success: true, new_keypair: false }, options);
     }
     console.log(`Account ${options.accountId} for network "${options.networkId}" was created.`);
-    await eventtracking.track(eventtracking.EVENT_ID_CREATE_ACCOUNT_END, { success: true }, options);
 }
 
 module.exports = {

--- a/commands/delete-key.js
+++ b/commands/delete-key.js
@@ -1,6 +1,5 @@
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
-const eventtracking = require('../utils/eventtracking');
 const inspectResponse = require('../utils/inspect-response');
 
 module.exports = {
@@ -16,11 +15,9 @@ module.exports = {
 };
 
 async function deleteAccessKey(options) {
-    await eventtracking.track(eventtracking.EVENT_ID_DELETE_KEY_START, { amount: options.amount }, options);
     console.log(`Deleting key = ${options.accessKey} on ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);
     const result = await account.deleteKey(options.accessKey);
     console.log(inspectResponse(result));
-    await eventtracking.track(eventtracking.EVENT_ID_DELETE_KEY_END, { success: true }, options);
 }

--- a/commands/delete-key.js
+++ b/commands/delete-key.js
@@ -16,11 +16,11 @@ module.exports = {
 };
 
 async function deleteAccessKey(options) {
-    await eventtracking.track(eventtracking.EVENT_ID_DELETE_KEY_START, { node: options.nodeUrl, amount: options.amount });
+    await eventtracking.track(eventtracking.EVENT_ID_DELETE_KEY_START, { amount: options.amount }, options);
     console.log(`Deleting key = ${options.accessKey} on ${options.accountId}.`);
     const near = await connect(options);
     const account = await near.account(options.accountId);
     const result = await account.deleteKey(options.accessKey);
     console.log(inspectResponse(result));
-    await eventtracking.track(eventtracking.EVENT_ID_DELETE_KEY_END, { node: options.nodeUrl, success: true });
+    await eventtracking.track(eventtracking.EVENT_ID_DELETE_KEY_END, { success: true }, options);
 }

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -32,8 +32,7 @@ module.exports = {
 };
 
 async function devDeploy(options) {
-    await eventtracking.askForConsentIfNeeded();
-    await eventtracking.track(eventtracking.EVENT_ID_DEV_DEPLOY_START, {}, options);
+    await eventtracking.askForConsentIfNeeded(options);
     const { nodeUrl, helperUrl, masterAccount, wasmFile } = options;
 
     if (!helperUrl && !masterAccount) {
@@ -48,7 +47,6 @@ async function devDeploy(options) {
     const account = await near.account(accountId);
     await account.deployContract(contractData);
     console.log(`Done deploying to ${accountId}`);
-    await eventtracking.track(eventtracking.EVENT_ID_DEV_DEPLOY_END, { success: true }, options);
 }
 
 async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -33,7 +33,7 @@ module.exports = {
 
 async function devDeploy(options) {
     await eventtracking.askForConsentIfNeeded();
-    await eventtracking.track(eventtracking.EVENT_ID_DEV_DEPLOY_START, { node: options.nodeUrl });
+    await eventtracking.track(eventtracking.EVENT_ID_DEV_DEPLOY_START, {}, options);
     const { nodeUrl, helperUrl, masterAccount, wasmFile } = options;
 
     if (!helperUrl && !masterAccount) {
@@ -48,7 +48,7 @@ async function devDeploy(options) {
     const account = await near.account(accountId);
     await account.deployContract(contractData);
     console.log(`Done deploying to ${accountId}`);
-    await eventtracking.track(eventtracking.EVENT_ID_DEV_DEPLOY_END, { node: options.nodeUrl, success: true });
+    await eventtracking.track(eventtracking.EVENT_ID_DEV_DEPLOY_END, { success: true }, options);
 }
 
 async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {

--- a/commands/generate-key.js
+++ b/commands/generate-key.js
@@ -6,20 +6,20 @@ module.exports = {
     command: 'generate-key <account-id>',
     desc: 'generate key ',
     builder: (yargs) => yargs,
-    handler: exitOnError(async (argv) => {
-        await eventtracking.track(eventtracking.EVENT_ID_GENERATE_KEY_START, { network: argv.networkId });
-        let near = await require('../utils/connect')(argv);
-        if (argv.accountId) {
+    handler: exitOnError(async (options) => {
+        await eventtracking.track(eventtracking.EVENT_ID_GENERATE_KEY_START, {}, options);
+        let near = await require('../utils/connect')(options);
+        if (options.accountId) {
             const { deps: { keyStore } } = near.config;
-            const existingKey = await keyStore.getKey(argv.networkId, argv.accountId);
+            const existingKey = await keyStore.getKey(options.networkId, options.accountId);
             if (existingKey) {
                 console.log(`Account has existing key pair with ${existingKey.publicKey} public key`);
             } else {
                 const keyPair = KeyPair.fromRandom('ed25519');
-                await keyStore.setKey(argv.networkId, argv.accountId, keyPair);
+                await keyStore.setKey(options.networkId, options.accountId, keyPair);
                 console.log(`Generated key pair with ${keyPair.publicKey} public key`);
             }
         }
-        await eventtracking.track(eventtracking.EVENT_ID_GENERATE_KEY_END, { network: argv.networkId, success: true });
+        await eventtracking.track(eventtracking.EVENT_ID_GENERATE_KEY_END, { success: true }, options);
     })
 };

--- a/commands/generate-key.js
+++ b/commands/generate-key.js
@@ -1,37 +1,31 @@
 const KeyPair = require('near-api-js').KeyPair;
 const exitOnError = require('../utils/exit-on-error');
-const eventtracking = require('../utils/eventtracking');
 
 module.exports = {
     command: 'generate-key <account-id>',
     desc: 'generate key ',
     builder: (yargs) => yargs,
     handler: exitOnError(async (argv) => {
-        try {
-            await eventtracking.track(eventtracking.EVENT_ID_GENERATE_KEY_START, {}, argv);
-            let near = await require('../utils/connect')(argv);
-            if (!argv.accountId) {
-                return;
-            }
-
-            if (argv.usingLedger) {
-                await argv.signer.getPublicKey();
-                // NOTE: Command above already prints public key
-                return;
-            }
-
-            const { deps: { keyStore } } = near.config;
-            const existingKey = await keyStore.getKey(argv.networkId, argv.accountId);
-            if (existingKey) {
-                console.log(`Account has existing key pair with ${existingKey.publicKey} public key`);
-                return;
-            }
-
-            const keyPair = KeyPair.fromRandom('ed25519');
-            await keyStore.setKey(argv.networkId, argv.accountId, keyPair);
-            console.log(`Generated key pair with ${keyPair.publicKey} public key`);
-        } finally {
-            await eventtracking.track(eventtracking.EVENT_ID_GENERATE_KEY_END, { success: true }, argv);
+        let near = await require('../utils/connect')(argv);
+        if (!argv.accountId) {
+            return;
         }
+
+        if (argv.usingLedger) {
+            await argv.signer.getPublicKey();
+            // NOTE: Command above already prints public key
+            return;
+        }
+
+        const { deps: { keyStore } } = near.config;
+        const existingKey = await keyStore.getKey(argv.networkId, argv.accountId);
+        if (existingKey) {
+            console.log(`Account has existing key pair with ${existingKey.publicKey} public key`);
+            return;
+        }
+
+        const keyPair = KeyPair.fromRandom('ed25519');
+        await keyStore.setKey(argv.networkId, argv.accountId, keyPair);
+        console.log(`Generated key pair with ${keyPair.publicKey} public key`);
     })
 };

--- a/commands/tx-status.js
+++ b/commands/tx-status.js
@@ -2,7 +2,6 @@ const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const inspectResponse = require('../utils/inspect-response');
 const bs58 = require('bs58');
-const eventtracking = require('../utils/eventtracking');
 
 module.exports = {
     command: 'tx-status <hash>',
@@ -14,7 +13,6 @@ module.exports = {
             required: true
         }),
     handler: exitOnError(async (argv) => {
-        await eventtracking.track(eventtracking.EVENT_ID_TX_STATUS_START, {}, argv);
         const near = await connect(argv);
 
         const hashParts = argv.hash.split(':');
@@ -35,6 +33,6 @@ module.exports = {
         const status = await near.connection.provider.txStatus(bs58.decode(hash), accountId);
         console.log(`Transaction ${accountId}:${hash}`);
         console.log(inspectResponse(status));
-        await eventtracking.track(eventtracking.EVENT_ID_TX_STATUS_END, { success: true }, argv);
+
     })
 };

--- a/commands/tx-status.js
+++ b/commands/tx-status.js
@@ -14,7 +14,7 @@ module.exports = {
             required: true
         }),
     handler: exitOnError(async (argv) => {
-        await eventtracking.track(eventtracking.EVENT_ID_TX_STATUS_START, {}, options);
+        await eventtracking.track(eventtracking.EVENT_ID_TX_STATUS_START, {}, argv);
         const near = await connect(argv);
 
         const hashParts = argv.hash.split(':');
@@ -35,6 +35,6 @@ module.exports = {
         const status = await near.connection.provider.txStatus(bs58.decode(hash), accountId);
         console.log(`Transaction ${accountId}:${hash}`);
         console.log(inspectResponse(status));
-        await eventtracking.track(eventtracking.EVENT_ID_TX_STATUS_END, { success: true }, options);
+        await eventtracking.track(eventtracking.EVENT_ID_TX_STATUS_END, { success: true }, argv);
     })
 };

--- a/commands/tx-status.js
+++ b/commands/tx-status.js
@@ -14,7 +14,7 @@ module.exports = {
             required: true
         }),
     handler: exitOnError(async (argv) => {
-        await eventtracking.track(eventtracking.EVENT_ID_TX_STATUS_START, { node: argv.nodeUrl });
+        await eventtracking.track(eventtracking.EVENT_ID_TX_STATUS_START, {}, options);
         const near = await connect(argv);
 
         const hashParts = argv.hash.split(':');
@@ -35,6 +35,6 @@ module.exports = {
         const status = await near.connection.provider.txStatus(bs58.decode(hash), accountId);
         console.log(`Transaction ${accountId}:${hash}`);
         console.log(inspectResponse(status));
-        await eventtracking.track(eventtracking.EVENT_ID_TX_STATUS_END, { node: argv.nodeUrl, success: true });
+        await eventtracking.track(eventtracking.EVENT_ID_TX_STATUS_END, { success: true }, options);
     })
 };

--- a/utils/crash-error-report.js
+++ b/utils/crash-error-report.js
@@ -1,7 +1,0 @@
-const eventtracking = require('./eventtracking');
-
-const mixPanelProperties = {
-    near_shell_command: process.env.NEAR_CLI_ERROR_LAST_COMMAND,
-    error_message: process.env.NEAR_CLI_LAST_ERROR
-};
-eventtracking.track(eventtracking.EVENT_ID_ERROR, mixPanelProperties, JSON.parse(process.env.NEAR_CLI_OPTIONS));

--- a/utils/crash-error-report.js
+++ b/utils/crash-error-report.js
@@ -2,7 +2,6 @@ const eventtracking = require('./eventtracking');
 
 const mixPanelProperties = {
     near_shell_command: process.env.NEAR_CLI_ERROR_LAST_COMMAND,
-    error_message: process.env.NEAR_CLI_LAST_ERROR,
-    network_id: process.env.NEAR_CLI_NETWORK_ID
+    error_message: process.env.NEAR_CLI_LAST_ERROR
 };
-eventtracking.track(eventtracking.EVENT_ID_ERROR, mixPanelProperties, process.env.NEAR_CLI_OPTIONS);
+eventtracking.track(eventtracking.EVENT_ID_ERROR, mixPanelProperties, JSON.parse(process.env.NEAR_CLI_OPTIONS));

--- a/utils/eventtracking.js
+++ b/utils/eventtracking.js
@@ -2,11 +2,8 @@ const MIXPANEL_TOKEN = '9aa8926fbcb03eb5d6ce787b5e8fa6eb';
 
 const chalk = require('chalk');  // colorize output
 const crypto = require('crypto');
-<<<<<<< HEAD
 const mixpanel = require('mixpanel').init(MIXPANEL_TOKEN);
 const near_cli_version = require('../package.json').version;
-=======
->>>>>>> master
 const readline = require('readline');
 const settings = require('./settings');
 const uuid = require('uuid');

--- a/utils/eventtracking.js
+++ b/utils/eventtracking.js
@@ -27,7 +27,7 @@ const shouldOptInByDefault = () => {
 
 const track = async (eventType, eventProperties) => {
     const shellSettings = settings.getShellSettings();
-    if (!shellSettings[TRACKING_ENABLED_KEY] && (!(TRACKING_ENABLED_KEY in shellSettings) || !shouldOptInByDefault())) {
+    if (!shellSettings[TRACKING_ENABLED_KEY] && (!(TRACKING_ENABLED_KEY in shellSettings) && !shouldOptInByDefault())) {
         return;
     }
     try {

--- a/utils/eventtracking.js
+++ b/utils/eventtracking.js
@@ -1,4 +1,4 @@
-const MIXPANEL_TOKEN = '9aa8926fbcb03eb5d6ce787b5e8fa6eb';
+const MIXPANEL_TOKEN = 'e98aa9d6d259d9d78f20cb05cb54f5cb';
 
 const chalk = require('chalk');  // colorize output
 const crypto = require('crypto');
@@ -86,54 +86,26 @@ const getEventTrackingConsent = async () => {
     }
 };
 
-const askForConsentIfNeeded = async () => {
+const askForConsentIfNeeded = async (options) => {
     const shellSettings = settings.getShellSettings();
     // if the appropriate option is not in settings, ask now and save settings.
     if (!(TRACKING_ENABLED_KEY in shellSettings)) {
         shellSettings[TRACKING_ENABLED_KEY] = shouldOptInByDefault() || await getEventTrackingConsent();
         shellSettings[TRACKING_SESSION_ID_KEY] = shellSettings[TRACKING_ENABLED_KEY] ? uuid.v4() : undefined;
         settings.saveShellSettings(shellSettings);
+        if (shellSettings[TRACKING_ENABLED_KEY]) {
+            track(module.exports.EVENT_ID_TRACKING_OPT_IN, {}, options);
+        }
     }
 };
 
 module.exports = {
     track,
     askForConsentIfNeeded,
-    // Event ids used in mixpanel. Note that we want to mention shell to make it very easy to tell that an event came from shell,
-    // since mixpanel might be used for other components as well.
-    EVENT_ID_ACCOUNT_STATE_START: 'shell_account_state_start',
-    EVENT_ID_ACCOUNT_STATE_END: 'shell_account_state_end',
-    EVENT_ID_DELETE_ACCOUNT_START: 'shell_delete_account_start',
-    EVENT_ID_DELETE_ACCOUNT_END: 'shell_delete_account_end',
-    EVENT_ID_ACCOUNT_KEYS_START: 'shell_account_keys_start',
-    EVENT_ID_ACCOUNT_KEYS_END: 'shell_account_keys_end',
-    EVENT_ID_TX_STATUS_START: 'shell_tx_status_start',
-    EVENT_ID_TX_STATUS_END: 'shell_tx_status_end',
-    EVENT_ID_BUILD_START: 'shell_build_start',
-    EVENT_ID_BUILD_END: 'shell_build_end',
-    EVENT_ID_LOGIN_START: 'shell_login_start',
-    EVENT_ID_LOGIN_END: 'shell_login_end',
-    EVENT_ID_DEPLOY_START: 'shell_deploy_start',
-    EVENT_ID_DEPLOY_END: 'shell_deploy_end',
-    EVENT_ID_DEV_DEPLOY_START: 'shell_dev_deploy_start',
-    EVENT_ID_DEV_DEPLOY_END: 'shell_dev_deploy_end',
-    EVENT_ID_CALL_VIEW_FN_START: 'shell_call_view_function_start',
-    EVENT_ID_CALL_VIEW_FN_END: 'shell_call_view_function_end',
-    EVENT_ID_SCHEDULE_FN_CALL_START: 'shell_schedule_fn_call_start',
-    EVENT_ID_SCHEDULE_FN_CALL_END: 'shell_schedule_fn_call_end',
-    EVENT_ID_SEND_TOKENS_START: 'shell_send_tokens_start',
-    EVENT_ID_SEND_TOKENS_END: 'shell_send_tokens_end',
-    EVENT_ID_CLEAN_START: 'shell_clean_start',
-    EVENT_ID_CLEAN_END: 'shell_clean_end',
-    EVENT_ID_STAKE_START: 'event_id_stake_start',
-    EVENT_ID_STAKE_END: 'event_id_stake_end',
-    EVENT_ID_CREATE_ACCOUNT_START: 'shell_create_account_start',
-    EVENT_ID_CREATE_ACCOUNT_END: 'shell_create_account_end',
-    EVENT_ID_REPL_START: 'shell_repl_start', // repl is currently broken so this is not used.
-    EVENT_ID_REPL_END: 'shell_repl_end',
-    EVENT_ID_GENERATE_KEY_START: 'shell_generate_key_start',
-    EVENT_ID_GENERATE_KEY_END: 'shell_id_generate_key_end',
-    EVENT_ID_DELETE_KEY_START: 'event_id_delete_key_start',
-    EVENT_ID_DELETE_KEY_END: 'event_id_delete_key_end',
+    // Some of the event ids are auto-generated runtime with the naming convention event_id_shell_{command}_start
+
+    EVENT_ID_CREATE_ACCOUNT_END: 'event_id_shell_create-account_end',
+    EVENT_ID_TRACKING_OPT_IN: 'event_id_tracking_opt_in',
+    EVENT_ID_LOGIN_END: 'event_id_shell_login_end',
     EVENT_ID_ERROR: 'event_id_shell_error'
 };

--- a/utils/eventtracking.js
+++ b/utils/eventtracking.js
@@ -3,15 +3,26 @@ const mixpanel = require('mixpanel').init(MIXPANEL_TOKEN);
 
 const uuid = require('uuid');
 const chalk = require('chalk');  // colorize output
+const crypto = require('crypto');
 const readline = require('readline');
 const settings = require('./settings');
 
 const TRACKING_ENABLED_KEY = 'trackingEnabled';
 const TRACKING_SESSION_ID_KEY = 'trackingSessionId';
 
+const isGitPod = () => {
+    return !!process.env.GITPOD_WORKSPACE_URL;
+}
+
+const getGitPodUserHash = () => {
+    if (!process.env.GITPOD_GIT_USER_NAME) {
+        return null;
+    }
+    return crypto.createHash('sha256').update(process.env.GITPOD_GIT_USER_NAME, 'utf8').digest('hex').toString();
+}
+
 const shouldOptInByDefault = () => {
-    const isGitPod = !!process.env.GITPOD_WORKSPACE_URL;
-    return isGitPod;
+    return isGitPod();
 };
 
 const track = async (eventType, eventProperties) => {
@@ -19,10 +30,10 @@ const track = async (eventType, eventProperties) => {
     if (!shellSettings[TRACKING_ENABLED_KEY] && (!(TRACKING_ENABLED_KEY in shellSettings) || !shouldOptInByDefault())) {
         return;
     }
-
     try {
         const mixPanelProperties = {
-            distinct_id: shellSettings[TRACKING_SESSION_ID_KEY]
+            distinct_id: isGitPod() ? getGitPodUserHash() : shellSettings[TRACKING_SESSION_ID_KEY],
+            is_gitpod: isGitPod()
         };
         Object.assign(mixPanelProperties, eventProperties);
         await mixpanel.track(eventType, mixPanelProperties);

--- a/utils/eventtracking.js
+++ b/utils/eventtracking.js
@@ -13,14 +13,14 @@ const TRACKING_SESSION_ID_KEY = 'trackingSessionId';
 
 const isGitPod = () => {
     return !!process.env.GITPOD_WORKSPACE_URL;
-}
+};
 
 const getGitPodUserHash = () => {
     if (!process.env.GITPOD_GIT_USER_NAME) {
         return null;
     }
     return crypto.createHash('sha256').update(process.env.GITPOD_GIT_USER_NAME, 'utf8').digest('hex').toString();
-}
+};
 
 const shouldOptInByDefault = () => {
     return isGitPod();
@@ -31,7 +31,7 @@ const shouldTrack = (shellSettings) => {
         return true;
     }
     return TRACKING_ENABLED_KEY in shellSettings && shellSettings[TRACKING_ENABLED_KEY];
-}
+};
 
 const track = async (eventType, eventProperties, options) => {
     const shellSettings = settings.getShellSettings();

--- a/utils/eventtracking.js
+++ b/utils/eventtracking.js
@@ -8,7 +8,6 @@ const readline = require('readline');
 const settings = require('./settings');
 const uuid = require('uuid');
 
-
 const TRACKING_ENABLED_KEY = 'trackingEnabled';
 const TRACKING_SESSION_ID_KEY = 'trackingSessionId';
 
@@ -34,7 +33,7 @@ const shouldTrack = (shellSettings) => {
     return TRACKING_ENABLED_KEY in shellSettings && shellSettings[TRACKING_ENABLED_KEY];
 }
 
-const track = async (eventType, eventProperties) => {
+const track = async (eventType, eventProperties, options) => {
     const shellSettings = settings.getShellSettings();
     if (!shouldTrack(shellSettings)) {
         return;
@@ -44,6 +43,9 @@ const track = async (eventType, eventProperties) => {
             distinct_id: isGitPod() ? getGitPodUserHash() : shellSettings[TRACKING_SESSION_ID_KEY],
             near_cli_version,
             os: process.platform,
+            network_id: options.networkId,
+            node_url: options.nodeUrl,
+            wallet_url: options.walletUrl,
             is_gitpod: isGitPod()
         };
         Object.assign(mixPanelProperties, eventProperties);

--- a/utils/eventtracking.js
+++ b/utils/eventtracking.js
@@ -1,11 +1,13 @@
 const MIXPANEL_TOKEN = '9aa8926fbcb03eb5d6ce787b5e8fa6eb';
-const mixpanel = require('mixpanel').init(MIXPANEL_TOKEN);
 
-const uuid = require('uuid');
 const chalk = require('chalk');  // colorize output
 const crypto = require('crypto');
+const mixpanel = require('mixpanel').init(MIXPANEL_TOKEN);
+const near_cli_version = require('../package.json').version;
 const readline = require('readline');
 const settings = require('./settings');
+const uuid = require('uuid');
+
 
 const TRACKING_ENABLED_KEY = 'trackingEnabled';
 const TRACKING_SESSION_ID_KEY = 'trackingSessionId';
@@ -40,6 +42,8 @@ const track = async (eventType, eventProperties) => {
     try {
         const mixPanelProperties = {
             distinct_id: isGitPod() ? getGitPodUserHash() : shellSettings[TRACKING_SESSION_ID_KEY],
+            near_cli_version,
+            os: process.platform,
             is_gitpod: isGitPod()
         };
         Object.assign(mixPanelProperties, eventProperties);

--- a/utils/eventtracking.js
+++ b/utils/eventtracking.js
@@ -25,9 +25,16 @@ const shouldOptInByDefault = () => {
     return isGitPod();
 };
 
+const shouldTrack = (shellSettings) => {
+    if (shouldOptInByDefault()) {
+        return true;
+    }
+    return TRACKING_ENABLED_KEY in shellSettings && shellSettings[TRACKING_ENABLED_KEY];
+}
+
 const track = async (eventType, eventProperties) => {
     const shellSettings = settings.getShellSettings();
-    if (!shellSettings[TRACKING_ENABLED_KEY] && (!(TRACKING_ENABLED_KEY in shellSettings) && !shouldOptInByDefault())) {
+    if (!shouldTrack(shellSettings)) {
         return;
     }
     try {

--- a/utils/exit-on-error.js
+++ b/utils/exit-on-error.js
@@ -1,26 +1,43 @@
+const eventtracking = require('./eventtracking');
+
 // This is a workaround to get Mixpanel to log a crash
 process.on('exit', () => {
-    require('child_process').fork(__dirname + '/crash-error-report.js', ['node'], {
+    const crashEventProperties = {
+        near_cli_command: process.env.NEAR_CLI_ERROR_LAST_COMMAND,
+        error_message: process.env.NEAR_CLI_LAST_ERROR
+    };
+    require('child_process').fork(__dirname + '/log-event.js', ['node'], {
         silent: true,
         detached: true,
         env: {
-            NEAR_CLI_ERROR_LAST_COMMAND: process.env.NEAR_CLI_ERROR_LAST_COMMAND,
-            NEAR_CLI_LAST_ERROR: process.env.NEAR_CLI_LAST_ERROR,
-            NEAR_CLI_NETWORK_ID: process.env.NEAR_CLI_NETWORK_ID,
+            NEAR_CLI_EVENT_ID: eventtracking.EVENT_ID_ERROR,
+            NEAR_CLI_EVENT_DATA: JSON.stringify(crashEventProperties),
             NEAR_CLI_OPTIONS: process.env.NEAR_CLI_OPTIONS
         }
     });
 });
 
 module.exports = (promiseFn) => async (...args) => {
-    process.env.NEAR_CLI_ERROR_LAST_COMMAND = args[0]['_'];
+    const command = args[0]['_'];
+    process.env.NEAR_CLI_ERROR_LAST_COMMAND = command;
     process.env.NEAR_CLI_NETWORK_ID = require('../get-config')()['networkId'];
+    const optionsAsStr = JSON.stringify(args[0]);
+    const eventId =  `event_id_shell_${command}_start`;
+    require('child_process').fork(__dirname + '/log-event.js', ['node'], {
+        silent: true,
+        detached: true,
+        env: {
+            NEAR_CLI_EVENT_ID: eventId,
+            NEAR_CLI_EVENT_DATA: JSON.stringify({}),
+            NEAR_CLI_OPTIONS: optionsAsStr
+        }
+    });
     const promise = promiseFn.apply(null, args);
     try {
         await promise;
     } catch (e) {
         process.env.NEAR_CLI_LAST_ERROR = e.message;
-        process.env.NEAR_CLI_OPTIONS = JSON.stringify(args[0]);
+        process.env.NEAR_CLI_OPTIONS = optionsAsStr;
         console.log('Error: ', e);
         process.exit(1);
     }

--- a/utils/exit-on-error.js
+++ b/utils/exit-on-error.js
@@ -20,7 +20,7 @@ module.exports = (promiseFn) => async (...args) => {
         await promise;
     } catch (e) {
         process.env.NEAR_CLI_LAST_ERROR = e.message;
-        process.env.NEAR_CLI_OPTIONS = args;
+        process.env.NEAR_CLI_OPTIONS = JSON.stringify(args[0]);
         console.log('Error: ', e);
         process.exit(1);
     }

--- a/utils/log-event.js
+++ b/utils/log-event.js
@@ -1,0 +1,6 @@
+const eventtracking = require('./eventtracking');
+
+eventtracking.track(
+    process.env.NEAR_CLI_EVENT_ID,
+    JSON.parse(process.env.NEAR_CLI_EVENT_DATA),
+    JSON.parse(process.env.NEAR_CLI_OPTIONS));

--- a/utils/verify-account.js
+++ b/utils/verify-account.js
@@ -21,19 +21,21 @@ module.exports = async (accountId, keyPair, options) => {
             await keyStore.setKey(options.networkId, accountId, keyPair);
             console.log(chalk`Logged in as [ {bold ${accountId}} ] with public key [ {bold ${short(publicKey)}} ] successfully\n`
             );
+            return true;
         } else {
             console.log(chalk`The account you provided {bold.red [ {bold.white ${accountId}} ] has not authorized the expected key [ {bold.white ${short(publicKey)}} ]}  Please try again.\n`
             );
+            return false;
         }
     } catch (e) {
         if (/Account ID/.test(e.message)) {
             console.log(chalk`\n{bold.red You need to provide a valid account ID to login}. Please try logging in again.\n`);
+            return false;
         } else if (/does not exist/.test(e.message)) {
             console.log(chalk`\nThe account you provided {bold.red [ {bold.white ${accountId}} ] does not exist on the [ {bold.white ${options.networkId}} ] network} (using ${options.nodeUrl})\n`);
+            return false;
         } else {
             throw e;
         }
     }
-
-    return;
 };


### PR DESCRIPTION
This PR refactors the way we track node url to be more consistent by using data from options instead of asking the caller to pass it.

This PR also contains an example of how we might want to add additional tracking to specific user flows to be to track user journeys. (see login)

Potential future work: log an event on invoking shell functions automatically