### PR TITLE
Add nagging for broken builds (nag devx@near.org)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,9 @@ cache: yarn
 script:
   - yarn lint
   - yarn test
-
+notifications:
+  email:
+      recipients:
+        - devx@near.org
+      on_success: never # default: change
+      on_failure: change # default: always


### PR DESCRIPTION
 The first stab is to notify only when build goes from green to red.
 We can ramp up the nagging if this is not sufficient.