### PR TITLE
refactor: remove obsolete --vanilla flag

### DIFF
--- a/test/test_account_operations.sh
+++ b/test/test_account_operations.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 rm  -rf tmp-project
-yarn create near-app --vanilla tmp-project
+yarn create near-app tmp-project
 cd tmp-project
 timestamp=$(date +%s)
 testaccount=testaccount$timestamp.test.near

--- a/test/test_contract.sh
+++ b/test/test_contract.sh
@@ -2,7 +2,7 @@
 set -ex
 rm  -rf tmp-project
 
-yarn create near-app --vanilla tmp-project
+yarn create near-app tmp-project
 
 cd tmp-project
 


### PR DESCRIPTION
near/create-near-app#387 removed the --vanilla flag and made vanilla JS the default; we can remove this flag here