### PR TITLE
Add a util for explorer functionality + unit tests

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,9 +9,6 @@ rules:
   indent:
     - error
     - 4
-  linebreak-style:
-    - error
-    - unix
   quotes:
     - error
     - single

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,6 +9,9 @@ rules:
   indent:
     - error
     - 4
+  linebreak-style:
+    - error
+    - unix
   quotes:
     - error
     - single

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -180,6 +180,11 @@ yargs // eslint-disable-line
         desc: 'Expected top-level account for a network',
         type: 'string'
     })
+    .option('explorerUrl', {
+        hidden: true,
+        desc: 'Base url for explorer',
+        type: 'string',
+    })
     .option('verbose', {
         desc: 'Prints out verbose output',
         type: 'boolean',

--- a/commands/call.js
+++ b/commands/call.js
@@ -32,5 +32,5 @@ async function scheduleFunctionCall(options) {
         options.gas,
         utils.format.parseNearAmount(options.amount));
     const result = providers.getTransactionLastResult(functionCallResponse);
-    console.log(inspectResponse(result));
+    console.log(inspectResponse.prettyPrintResponse(result));
 }

--- a/commands/delete-key.js
+++ b/commands/delete-key.js
@@ -19,5 +19,5 @@ async function deleteAccessKey(options) {
     const near = await connect(options);
     const account = await near.account(options.accountId);
     const result = await account.deleteKey(options.accessKey);
-    console.log(inspectResponse(result));
+    console.log(inspectResponse.prettyPrintResponse(result));
 }

--- a/commands/tx-status.js
+++ b/commands/tx-status.js
@@ -32,7 +32,7 @@ module.exports = {
 
         const status = await near.connection.provider.txStatus(bs58.decode(hash), accountId);
         console.log(`Transaction ${accountId}:${hash}`);
-        console.log(inspectResponse(status));
+        console.log(inspectResponse.prettyPrintResponse(status));
 
     })
 };

--- a/config.js
+++ b/config.js
@@ -12,6 +12,7 @@ function getConfig(env) {
             walletUrl: 'https://wallet.near.org',
             helperUrl: 'https://helper.mainnet.near.org',
             helperAccount: 'near',
+            explorerUrl: 'https://explorer.mainnet.near.org',
         };
     case 'development':
     case 'testnet':
@@ -22,6 +23,7 @@ function getConfig(env) {
             walletUrl: 'https://wallet.testnet.near.org',
             helperUrl: 'https://helper.testnet.near.org',
             helperAccount: 'testnet',
+            explorerUrl: 'https://explorer.testnet.near.org',
         };
     case 'devnet':
         return {
@@ -31,6 +33,7 @@ function getConfig(env) {
             walletUrl: 'https://wallet.devnet.near.org',
             helperUrl: 'https://helper.devnet.near.org',
             helperAccount: 'devnet',
+            explorerUrl: 'https://explorer.devnet.near.org/',
         };
     case 'betanet':
         return {
@@ -40,6 +43,7 @@ function getConfig(env) {
             walletUrl: 'https://wallet.betanet.near.org',
             helperUrl: 'https://helper.betanet.near.org',
             helperAccount: 'betanet',
+            explorerUrl: 'https://explorer.testnet.near.org',
         };
     case 'local':
         return {

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const capture = require('./utils/capture-login-success');
 
 const inspectResponse = require('./utils/inspect-response');
 const eventtracking = require('./utils/eventtracking');
+const explorer = require('./utils/explorer');
 
 // TODO: Fix promisified wrappers to handle error properly
 
@@ -44,7 +45,7 @@ exports.callViewFunction = async function (options) {
     console.log(`View call: ${options.contractName}.${options.methodName}(${options.args || ''})`);
     const near = await connect(options);
     const account = await near.account(options.accountId || options.masterAccount || options.contractName);
-    console.log(inspectResponse(await account.viewFunction(options.contractName, options.methodName, JSON.parse(options.args || '{}'))));
+    console.log(inspectResponse.prettyPrintResponse(await account.viewFunction(options.contractName, options.methodName, JSON.parse(options.args || '{}'))));
 };
 
 // open a given URL in browser in a safe way.
@@ -159,7 +160,7 @@ exports.viewAccount = async function (options) {
         state['formattedAmount'] = utils.format.formatNearAmount(state.amount);
     }
     console.log(`Account ${options.accountId}`);
-    console.log(inspectResponse(state));
+    console.log(inspectResponse.prettyPrintResponse(state));
 };
 
 exports.deleteAccount = async function (options) {
@@ -177,14 +178,16 @@ exports.keys = async function (options) {
     let account = await near.account(options.accountId);
     let accessKeys = await account.getAccessKeys();
     console.log(`Keys for account ${options.accountId}`);
-    console.log(inspectResponse(accessKeys));
+    console.log(inspectResponse.prettyPrintResponse(accessKeys));
 };
 
 exports.sendMoney = async function (options) {
     console.log(`Sending ${options.amount} NEAR to ${options.receiver} from ${options.sender}`);
     const near = await connect(options);
     const account = await near.account(options.sender);
-    console.log(inspectResponse(await account.sendMoney(options.receiver, utils.format.parseNearAmount(options.amount))));
+    const result = await account.sendMoney(options.receiver, utils.format.parseNearAmount(options.amount));
+    console.log(inspectResponse.prettyPrintResponse(result));
+    explorer.printTransactionUrl(inspectResponse.getTxnId(result), options);
 };
 
 exports.stake = async function (options) {
@@ -192,7 +195,7 @@ exports.stake = async function (options) {
     const near = await connect(options);
     const account = await near.account(options.accountId);
     const result = await account.stake(qs.unescape(options.stakingKey), utils.format.parseNearAmount(options.amount));
-    console.log(inspectResponse(result));
+    console.log(inspectResponse.prettyPrintResponse(result));
 };
 
 exports.build = async function () {

--- a/index.js
+++ b/index.js
@@ -186,8 +186,12 @@ exports.sendMoney = async function (options) {
     const near = await connect(options);
     const account = await near.account(options.sender);
     const result = await account.sendMoney(options.receiver, utils.format.parseNearAmount(options.amount));
-    console.log(inspectResponse.prettyPrintResponse(result));
-    explorer.printTransactionUrl(inspectResponse.getTxnId(result), options);
+    if (options.verbose) {
+        console.log(inspectResponse.prettyPrintResponse(result));
+    }
+    const txnId = inspectResponse.getTxnId(result);
+    console.log(`Transaction Id ${txnId}`);
+    explorer.printTransactionUrl(txnId, options);
 };
 
 exports.stake = async function (options) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "./test/index.sh",
+    "test": "jest && ./test/index.sh",
     "lint": "eslint .",
     "fix": "eslint . --fix"
   },
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "eslint": "^7.0.0",
-    "jest": "^26.0.1",
+    "jest": "^26.1.0",
     "strip-ansi": "^6.0.0",
     "strip-ansi-cli": "^2.0.0"
   },

--- a/test/unit/explorer.test.js
+++ b/test/unit/explorer.test.js
@@ -4,13 +4,13 @@ const explorer = require('../../utils/explorer');
 describe('generate explorer link', () => {
     test('on environment with a known url', async () => {
         const config = require('../../config')('development');
-        const url = explorer.generateTransactionUrl("61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY", config);            
+        const url = explorer.generateTransactionUrl('61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY', config);            
         expect(url).toEqual('https://explorer.testnet.near.org/transactions/61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY');
     });
 
     test('on environment with an unknown url', async () => {
         const config = require('../../config')('ci');
-        const url = explorer.generateTransactionUrl("61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY", config);
+        const url = explorer.generateTransactionUrl('61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY', config);
         expect(url).toEqual(null);
     });
 
@@ -21,8 +21,7 @@ describe('generate explorer link', () => {
     });
 
     test('null options', async () => {
-        const config = require('../../config')('development');
-        const url = explorer.generateTransactionUrl("61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY", null);
+        const url = explorer.generateTransactionUrl('61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY', null);
         expect(url).toEqual(null);
     });
 });

--- a/test/unit/explorer.test.js
+++ b/test/unit/explorer.test.js
@@ -1,0 +1,24 @@
+
+const explorer = require('../../utils/explorer');
+
+describe('generate explorer link', () => {
+    test('on environment with a known url', async () => {
+        const config = require('../../config')('development');
+        const url = explorer.generateTransactionUrl("61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY", config);
+        expect(url).toEqual('https://explorer.testnet.near.org/transactions/61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY');
+    });
+
+    test('on environment with an unknown url', async () => {
+        const config = require('../../config')('ci');
+        const url = explorer.generateTransactionUrl("61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY", config);
+        expect(url).toEqual(null);
+    });
+
+    test('no explorer url in config (old config version)', async () => {
+        // we may decide to handle this by adding a map of known environments.
+        const config = require('../../config')('ci');
+        delete config.explorerUrl;
+        const url = explorer.generateTransactionUrl("61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY", config);
+        expect(url).toEqual(null);
+    });
+});

--- a/test/unit/explorer.test.js
+++ b/test/unit/explorer.test.js
@@ -4,7 +4,7 @@ const explorer = require('../../utils/explorer');
 describe('generate explorer link', () => {
     test('on environment with a known url', async () => {
         const config = require('../../config')('development');
-        const url = explorer.generateTransactionUrl("61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY", config);
+        const url = explorer.generateTransactionUrl("61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY", config);            
         expect(url).toEqual('https://explorer.testnet.near.org/transactions/61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY');
     });
 
@@ -14,11 +14,15 @@ describe('generate explorer link', () => {
         expect(url).toEqual(null);
     });
 
-    test('no explorer url in config (old config version)', async () => {
-        // we may decide to handle this by adding a map of known environments.
-        const config = require('../../config')('ci');
-        delete config.explorerUrl;
-        const url = explorer.generateTransactionUrl("61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY", config);
+    test('unknown txn id', async () => {
+        const config = require('../../config')('development');
+        const url = explorer.generateTransactionUrl(null, config);
+        expect(url).toEqual(null);
+    });
+
+    test('null options', async () => {
+        const config = require('../../config')('development');
+        const url = explorer.generateTransactionUrl("61Uc5f7L42SDWFPYHx7goMc2xEN7YN4fgtw9baHA82hY", null);
         expect(url).toEqual(null);
     });
 });

--- a/test/unit/inspect-response.test.js
+++ b/test/unit/inspect-response.test.js
@@ -1,0 +1,20 @@
+const inspectResponse = require('../../utils/inspect-response');
+
+describe('getTxnId', () => {
+    test('with expected data format', async () => {
+        const data =  {
+            transaction: {
+                hash: 'BF1iyVWTkagisho3JKKUXiPQu2sMuuLsEbvQBDYHHoKE'
+            }
+        };
+        expect(inspectResponse.getTxnId(data)).toEqual('BF1iyVWTkagisho3JKKUXiPQu2sMuuLsEbvQBDYHHoKE');
+    });
+
+    test('with null response', async () => {
+        expect(inspectResponse.getTxnId(null)).toEqual(null);
+    });
+
+    test('with null transaction inside response', async () => {
+        expect(inspectResponse.getTxnId({})).toEqual(null);
+    });
+});

--- a/utils/explorer.js
+++ b/utils/explorer.js
@@ -1,0 +1,11 @@
+// Handle functionality related to explorer
+
+const generateTransactionUrl = (txnId, options) => {
+    const explorerUrl = options.explorerUrl;
+
+    return explorerUrl ? `${options.explorerUrl}/transactions/${txnId}` : null;
+};
+
+module.exports = {
+    generateTransactionUrl,
+};

--- a/utils/explorer.js
+++ b/utils/explorer.js
@@ -11,7 +11,7 @@ const generateTransactionUrl = (txnId, options) => {
 const printTransactionUrl = (txnId, options) => {
     const txnUrl = generateTransactionUrl(txnId, options);
     if (txnUrl) {
-        console.log('To see the transaction in the transaction explorer, please open this url in your browser.')
+        console.log('To see the transaction in the transaction explorer, please open this url in your browser.');
         console.log(txnUrl);
     }
 };

--- a/utils/explorer.js
+++ b/utils/explorer.js
@@ -11,7 +11,7 @@ const generateTransactionUrl = (txnId, options) => {
 const printTransactionUrl = (txnId, options) => {
     const txnUrl = generateTransactionUrl(txnId, options);
     if (txnUrl) {
-        console.log('To see the transaction in the transaction explorer, please open this url in your browser.');
+        console.log('To see the transaction in the transaction explorer, please open this url in your browser');
         console.log(txnUrl);
     }
 };

--- a/utils/explorer.js
+++ b/utils/explorer.js
@@ -1,11 +1,22 @@
 // Handle functionality related to explorer
 
 const generateTransactionUrl = (txnId, options) => {
+    if (!txnId || !options) {
+        return null;
+    }
     const explorerUrl = options.explorerUrl;
+    return explorerUrl ? `${explorerUrl}/transactions/${txnId}` : null;
+};
 
-    return explorerUrl ? `${options.explorerUrl}/transactions/${txnId}` : null;
+const printTransactionUrl = (txnId, options) => {
+    const txnUrl = generateTransactionUrl(txnId, options);
+    if (txnUrl) {
+        console.log('To see the transaction in the transaction explorer, please open this url in your browser.')
+        console.log(txnUrl);
+    }
 };
 
 module.exports = {
     generateTransactionUrl,
+    printTransactionUrl,
 };

--- a/utils/inspect-response.js
+++ b/utils/inspect-response.js
@@ -1,5 +1,24 @@
 
 const util = require('util');
-module.exports = (response) => {
+const prettyPrintResponse = (response) => {
     return util.inspect(response, { showHidden: true, depth: null, colors: true, maxArrayLength: null });
 };
+
+const getTxnId = (response) => {
+    // Currently supported response format: 
+    //{
+    //   ...
+    //   transaction: {
+    //     ...
+    //     hash: 'BF1iyVWTkagisho3JKKUXiPQu2sMuuLsEbvQBDYHHoKE'
+    //   },
+    if (!response || !response.transaction) {
+        return null;
+    }
+    return response.transaction.hash;
+};
+
+module.exports = {
+    prettyPrintResponse,
+    getTxnId,
+}

--- a/utils/inspect-response.js
+++ b/utils/inspect-response.js
@@ -21,4 +21,4 @@ const getTxnId = (response) => {
 module.exports = {
     prettyPrintResponse,
     getTxnId,
-}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2915,7 +2915,7 @@ jest-worker@^26.1.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest@^26.0.1:
+jest@^26.1.0:
   version "26.1.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-26.1.0.tgz#2f3aa7bcffb9bfd025473f83bbbf46a3af026263"
   integrity sha512-LIti8jppw5BcQvmNJe4w2g1N/3V68HUfAv9zDVm7v+VAtQulGhH0LnmmiVkbNE4M4I43Bj2fXPiBGKt26k9tHw==


### PR DESCRIPTION
near send will now print a link to explorer url at the end of the output, if there is a known explorer url and also if transaction id is known. 

This is needed for https://github.com/near/near-shell/issues/410