### PR TITLE
Remove "build" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ near <command>
 
 #### For smart contract:
 ```bash
-  near build                                       # build your smart contract
   near deploy                                      # deploy your smart contract
   near call <contractName> <methodName> [args]     # schedule smart contract call which can modify state
   near view <contractName> <methodName> [args]     # make smart contract call which can view state

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -114,12 +114,6 @@ const callViewFunction = {
     handler: exitOnError(main.callViewFunction)
 };
 
-const build = {
-    command: 'build',
-    desc: 'build your smart contract',
-    handler: exitOnError(main.build)
-};
-
 const clean = {
     command: 'clean',
     desc: 'clean the build environment',
@@ -196,7 +190,6 @@ yargs // eslint-disable-line
     .command(deleteAccount)
     .command(keys)
     .command(require('../commands/tx-status'))
-    .command(build)
     .command(deploy)
     .command(require('../commands/dev-deploy'))
     .command(require('../commands/call'))

--- a/index.js
+++ b/index.js
@@ -194,16 +194,3 @@ exports.stake = async function (options) {
     const result = await account.stake(qs.unescape(options.stakingKey), utils.format.parseNearAmount(options.amount));
     console.log(inspectResponse(result));
 };
-
-exports.build = async function () {
-    const gulp = spawn('gulp', [], { shell: process.platform == 'win32' });
-    gulp.stdout.on('data', function (data) {
-        console.log(data.toString());
-    });
-    gulp.stderr.on('data', function (data) {
-        console.log(data.toString());
-    });
-    gulp.on('exit', function (code) {
-        process.exit(code);
-    });
-};

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ const URL = require('url').URL;
 const qs = require('querystring');
 const chalk = require('chalk');  // colorize output
 const open = require('open');    // open URL in default browser
-const { spawn } = require('child_process');
 const { KeyPair, utils } = require('near-api-js');
 
 const connect = require('./utils/connect');


### PR DESCRIPTION
fixes #205 
The `build` command runs `gulp`, which early on was used to build AssemblyScript contracts. That is not the case anymore, and gulp has been removed from all relevant examples and repositories. Therefore, this build command is confusing, and developers will be using other means (scripts, likely) to build contracts.