### PR TITLE
tests: create_account » create-account

### DIFF
--- a/test/test_account_creation.sh
+++ b/test/test_account_creation.sh
@@ -4,7 +4,7 @@ set -ex
 timestamp=$(date +%s)
 testaccount=testaccount$timestamp.test.near
 
-RESULT=$(./bin/near create_account $testaccount --masterAccount test.far -v)
+RESULT=$(./bin/near create-account $testaccount --masterAccount test.far -v)
 echo $RESULT
 EXPECTED=".+New account doesn't share the same top-level account.+ "
 if [[ ! "$RESULT" =~ $EXPECTED ]]; then
@@ -12,7 +12,7 @@ if [[ ! "$RESULT" =~ $EXPECTED ]]; then
     exit 1
 fi
 
-RESULT=$(./bin/near create_account tooshortfortla -v)
+RESULT=$(./bin/near create-account tooshortfortla -v)
 echo $RESULT
 EXPECTED=".+Top-level accounts must be at least.+ "
 if [[ ! "$RESULT" =~ $EXPECTED ]]; then

--- a/test/test_account_operations.sh
+++ b/test/test_account_operations.sh
@@ -6,7 +6,7 @@ cd tmp-project
 timestamp=$(date +%s)
 testaccount=testaccount$timestamp.test.near
 echo Create account
-../bin/near create_account $testaccount
+../bin/near create-account $testaccount
 
 echo Get account state
 RESULT=$(../bin/near state $testaccount -v | ../node_modules/.bin/strip-ansi)

--- a/test/test_contract.sh
+++ b/test/test_contract.sh
@@ -8,7 +8,7 @@ cd tmp-project
 
 timestamp=$(date +%s)
 testaccount=testaccount$timestamp.test.near
-../bin/near create_account $testaccount
+../bin/near create-account $testaccount
 
 echo Building contract
 yarn install


### PR DESCRIPTION
We have changed `create_account` to `create-account` but the tests still used the old format. Fixed that.