### PR TITLE
Fix explorer link for betanet env

### DIFF
--- a/config.js
+++ b/config.js
@@ -43,7 +43,7 @@ function getConfig(env) {
             walletUrl: 'https://wallet.betanet.near.org',
             helperUrl: 'https://helper.betanet.near.org',
             helperAccount: 'betanet',
-            explorerUrl: 'https://explorer.testnet.near.org',
+            explorerUrl: 'https://explorer.betanet.near.org',
         };
     case 'local':
         return {


### PR DESCRIPTION
Tested: 

Transaction Id 6hKKZngEVVzgjBN8Tnk2QAjs67Kz6jiUzVtiwGDA2hSj
To see the transaction in the transaction explorer, please open this url in your browser
https://explorer.betanet.near.org/transactions/6hKKZngEVVzgjBN8Tnk2QAjs67Kz6jiUzVtiwGDA2hSj