### PR TITLE
Use transaction id from error to print out explorer link for errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jest-environment-node": "^26.0.0",
     "mixpanel": "^0.11.0",
     "ncp": "^2.0.0",
-    "near-api-js": "^0.27.0",
+    "near-api-js": "^0.28.0",
     "open": "^7.0.1",
     "rimraf": "^3.0.0",
     "stoppable": "^1.1.0",

--- a/utils/exit-on-error.js
+++ b/utils/exit-on-error.js
@@ -1,4 +1,5 @@
 const eventtracking = require('./eventtracking');
+const inspectResponse = require('./inspect-response');
 
 // This is a workaround to get Mixpanel to log a crash
 process.on('exit', () => {
@@ -21,7 +22,8 @@ module.exports = (promiseFn) => async (...args) => {
     const command = args[0]['_'];
     process.env.NEAR_CLI_ERROR_LAST_COMMAND = command;
     process.env.NEAR_CLI_NETWORK_ID = require('../get-config')()['networkId'];
-    const optionsAsStr = JSON.stringify(args[0]);
+    const options = args[0];
+    const optionsAsStr = JSON.stringify(options);
     const eventId =  `event_id_shell_${command}_start`;
     require('child_process').fork(__dirname + '/log-event.js', ['node'], {
         silent: true,
@@ -38,7 +40,7 @@ module.exports = (promiseFn) => async (...args) => {
     } catch (e) {
         process.env.NEAR_CLI_LAST_ERROR = e.message;
         process.env.NEAR_CLI_OPTIONS = optionsAsStr;
-        console.log('Error: ', e);
+        inspectResponse.prettyPrintError(e, options);
         process.exit(1);
     }
 };

--- a/utils/inspect-response.js
+++ b/utils/inspect-response.js
@@ -10,10 +10,33 @@ const prettyPrintResponse = (response, options) => {
     explorer.printTransactionUrl(txnId, options);
 };
 
+const prettyPrintError = (error, options) => {
+    console.log(`An error occured`)
+    console.log(formatResponse(error));
+    const txnId = getTxnIdFromError(error);
+    if (txnId) {
+        console.log(`We attempted to send a transaction with id ${txnId} to NEAR, but something went wrong.`);
+        explorer.printTransactionUrl(txnId, options);
+    }
+};
+
 const formatResponse = (response) => {
     return util.inspect(response, { showHidden: true, depth: null, colors: true, maxArrayLength: null });
-
 };
+
+const getTxnIdFromError = (error) => {
+    // Currently supported error format: 
+    // TypedError: Exceeded 10 status check attempts for transaction GRPWi935e8Cm2PmPqrcrAyBuM9N13h5kHJNqhfVcY33q.
+    // at Account.retryTxResult (C:\Users\janed\near\near-api-js\lib\account.js:97:15)
+    // at Account.signAndSendTransaction (C:\Users\janed\near\near-api-js\lib\account.js:119:22)
+    // at Object. (C:\Users\janed\near\near-api-js\test\account.test.js:38:5) {
+    // type: 'RetriesExceeded',
+    // transactionHash: 'GRPWi935e8Cm2PmPqrcrAyBuM9N13h5kHJNqhfVcY33q'
+    // } 
+    
+    if (!error) return null;
+    return error.transactionHash;
+}
 
 const getTxnId = (response) => {
     // Currently supported response format: 
@@ -31,6 +54,7 @@ const getTxnId = (response) => {
 
 module.exports = {
     prettyPrintResponse,
+    prettyPrintError,
     formatResponse,
     getTxnId,
 };

--- a/utils/inspect-response.js
+++ b/utils/inspect-response.js
@@ -17,7 +17,7 @@ const prettyPrintError = (error, options) => {
     if (txnId) {
         console.log(`We attempted to send transaction ${txnId} to NEAR, but something went wrong.`);
         explorer.printTransactionUrl(txnId, options);
-        console.log('Note: if the transaction was invalid (e.g. not enough balance), it will show as Not started/Finalizing.');
+        console.log('Note: if the transaction was invalid (e.g. not enough balance), it will show as "Not started" or "Finalizing"');
     }
 };
 

--- a/utils/inspect-response.js
+++ b/utils/inspect-response.js
@@ -11,12 +11,13 @@ const prettyPrintResponse = (response, options) => {
 };
 
 const prettyPrintError = (error, options) => {
-    console.log(`An error occured`)
+    console.log('An error occured');
     console.log(formatResponse(error));
     const txnId = getTxnIdFromError(error);
     if (txnId) {
-        console.log(`We attempted to send a transaction with id ${txnId} to NEAR, but something went wrong.`);
+        console.log(`We attempted to send transaction ${txnId} to NEAR, but something went wrong.`);
         explorer.printTransactionUrl(txnId, options);
+        console.log('Note: if the transaction was invalid (e.g. not enough balance), it will show as Not started/Finalizing.');
     }
 };
 
@@ -26,17 +27,22 @@ const formatResponse = (response) => {
 
 const getTxnIdFromError = (error) => {
     // Currently supported error format: 
-    // TypedError: Exceeded 10 status check attempts for transaction GRPWi935e8Cm2PmPqrcrAyBuM9N13h5kHJNqhfVcY33q.
-    // at Account.retryTxResult (C:\Users\janed\near\near-api-js\lib\account.js:97:15)
-    // at Account.signAndSendTransaction (C:\Users\janed\near\near-api-js\lib\account.js:119:22)
-    // at Object. (C:\Users\janed\near\near-api-js\test\account.test.js:38:5) {
-    // type: 'RetriesExceeded',
-    // transactionHash: 'GRPWi935e8Cm2PmPqrcrAyBuM9N13h5kHJNqhfVcY33q'
-    // } 
+    // {
+    //     [stack]: 'Error: Sender jane.betanet does not have enough balance 45000000521675913419670000 for operation costing 1000000000002265303009375000\n' +
+    //     ...
+    //     [message]: 'Sender jane.betanet does not have enough balance 45000000521675913419670000 for operation costing 1000000000002265303009375000',
+    //     type: 'NotEnoughBalance',
+    //     context: ErrorContext {
+    //       transactionHash: 'FyavUCyvZ5G1JLTdnXSZd3VoaFEaGRXnmDFwhmNeaVC6'
+    //     },
+    //     balance: '45000000521675913419670000',
+    //     cost: '1000000000002265303009375000',
+    //     signer_id: 'jane.betanet'
+    //   }
     
-    if (!error) return null;
-    return error.transactionHash;
-}
+    if (!error || !error.context) return null;
+    return error.context.transactionHash;
+};
 
 const getTxnId = (response) => {
     // Currently supported response format: 


### PR DESCRIPTION
Note that there is currently no good way to tell if a transaction got included in the chain without an extra RPC, so sometimes this link will not be valid. 

To reproduce error behavior, the easiest way is to try to send too much money to another account
e.g. 
>node bin\near send jane.betanet jane2.betanet 1000 

This depends on https://github.com/near/near-api-js/pull/362