### PR TITLE
Fix missing transaction id on call methods

### DIFF
--- a/commands/call.js
+++ b/commands/call.js
@@ -33,4 +33,5 @@ async function scheduleFunctionCall(options) {
         utils.format.parseNearAmount(options.amount));
     const result = providers.getTransactionLastResult(functionCallResponse);
     inspectResponse.prettyPrintResponse(functionCallResponse, options);
+    console.log(inspectResponse.formatResponse(result));
 }

--- a/commands/call.js
+++ b/commands/call.js
@@ -32,5 +32,5 @@ async function scheduleFunctionCall(options) {
         options.gas,
         utils.format.parseNearAmount(options.amount));
     const result = providers.getTransactionLastResult(functionCallResponse);
-    inspectResponse.prettyPrintResponse(result, options);
+    inspectResponse.prettyPrintResponse(functionCallResponse, options);
 }


### PR DESCRIPTION
Tested: `node bin\near call stakingpool.youlaiwuqu.betanet ping '{}' --accountId jane.betanet`

```
Scheduling a call: stakingpool.youlaiwuqu.betanet.ping({})
Transaction Id Av6RZjt6PvXm9mcJL4jzcA18ojLCPY2yfoJZ9G6R7GPe
To see the transaction in the transaction explorer, please open this url in your browser
https://explorer.betanet.near.org/transactions/Av6RZjt6PvXm9mcJL4jzcA18ojLCPY2yfoJZ9G6R7GPe
```