### PR TITLE
Improve help for view/call operations

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -128,7 +128,12 @@ const deploy = {
 const callViewFunction = {
     command: 'view <contractName> <methodName> [args]',
     desc: 'make smart contract call which can view state',
-    builder: (yargs) => yargs,
+    builder: (yargs) => yargs
+        .option('args', {
+            desc: 'Arguments to the view call, in JSON format (e.g. \'{"param_a": "value"}\')',
+            type: 'string',
+            default: null
+        }),
     handler: exitOnError(main.callViewFunction)
 };
 

--- a/commands/call.js
+++ b/commands/call.js
@@ -16,6 +16,14 @@ module.exports = {
             desc: 'Number of tokens to attach',
             type: 'string',
             default: '0'
+        })
+        .option('args', {
+            desc: 'Arguments to the contract call, in JSON format (e.g. \'{"param_a": "value"}\')',
+            type: 'string',
+            default: null
+        })
+        .option('accountId', {
+            required: true,
         }),
     handler: exitOnError(scheduleFunctionCall)
 };

--- a/commands/call.js
+++ b/commands/call.js
@@ -24,6 +24,8 @@ module.exports = {
         })
         .option('accountId', {
             required: true,
+            desc: 'Unique identifier for the account that will be used to sign this call',
+            type: 'string',
         }),
     handler: exitOnError(scheduleFunctionCall)
 };


### PR DESCRIPTION
Tested 
node bin\near call -help
near call <contractName> <methodName> [args]

schedule smart contract call which can modify state

Options:
  --help                     Show help  [boolean]
  --version                  Show version number  [boolean]
  --nodeUrl, --node_url      NEAR node URL  [string] [default: "https://rpc.betanet.near.org"]
  --networkId, --network_id  NEAR network ID, allows using different keys based on network  [string] [default: "betanet"]
  --helperUrl                NEAR contract helper URL  [string]
  --keyPath                  Path to master account key  [string]
  --accountId, --account_id  Unique identifier for the account that will be used to sign this call  [string] [required]
  --useLedgerKey             Use Ledger for signing with given HD key path  [string] [default: "44'/397'/0'/0'/1'"]
  --walletUrl                Website for NEAR Wallet  [string]
  --contractName             Account name of contract  [string]
  --masterAccount            Master account used when creating new accounts  [string]
  --helperAccount            Expected top-level account for a network  [string]
  --verbose, -v              Prints out verbose output  [boolean] [default: false]
  --gas                      Max amount of gas this call can use  [string] [default: "100000000000000"]
  --amount                   Number of tokens to attach  [string] [default: "0"]
  --args                     Arguments to the contract call, in JSON format (e.g. '{"param_a": "value"}')  [string] [default: null]


node bin\near view --help
near view <contractName> <methodName> [args]

make smart contract call which can view state

Options:
  --help                     Show help  [boolean]
  --version                  Show version number  [boolean]
  --nodeUrl, --node_url      NEAR node URL  [string] [default: "https://rpc.betanet.near.org"]
  --networkId, --network_id  NEAR network ID, allows using different keys based on network  [string] [default: "betanet"]
  --helperUrl                NEAR contract helper URL  [string]
  --keyPath                  Path to master account key  [string]
  --accountId, --account_id  Unique identifier for the account  [string]
  --useLedgerKey             Use Ledger for signing with given HD key path  [string] [default: "44'/397'/0'/0'/1'"]
  --walletUrl                Website for NEAR Wallet  [string]
  --contractName             Account name of contract  [string]
  --masterAccount            Master account used when creating new accounts  [string]
  --helperAccount            Expected top-level account for a network  [string]
  --verbose, -v              Prints out verbose output  [boolean] [default: false]
  --args                     Arguments to the view call, in JSON format (e.g. '{"param_a": "value"}')  [string] [default: null]
